### PR TITLE
Make pipeline name more readable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ on:
 
 jobs:
 
-  build:
-    name: Build
+  ci:
+    name: Run CI
     runs-on: ubuntu-latest
     steps:
 


### PR DESCRIPTION
Right now it shows up in various places as "Build" which isn't really
what it does.