### PR TITLE
Update linter and fix linting problems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,5 +28,5 @@ lint:
 
 .PHONY: tools
 tools:
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.2
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.49.0
 	go install github.com/rinchsan/gosimports/cmd/gosimports@latest # https://github.com/golang/go/issues/20818

--- a/di/inject_adapters.go
+++ b/di/inject_adapters.go
@@ -18,7 +18,7 @@ import (
 	"go.etcd.io/bbolt"
 )
 
-//nolint:deadcode,varcheck
+//nolint:unused
 var txBoltAdaptersSet = wire.NewSet(
 	bolt.NewFeedRepository,
 	wire.Bind(new(commands.FeedRepository), new(*bolt.FeedRepository)),
@@ -36,7 +36,7 @@ var txBoltAdaptersSet = wire.NewSet(
 	bolt.NewBlobRepository,
 )
 
-//nolint:deadcode,varcheck
+//nolint:unused
 var boltAdaptersSet = wire.NewSet(
 	bolt.NewReadFeedRepository,
 	wire.Bind(new(queries.FeedRepository), new(*bolt.ReadFeedRepository)),
@@ -57,7 +57,7 @@ var boltAdaptersSet = wire.NewSet(
 	newTxRepositoriesFactory,
 )
 
-//nolint:deadcode,varcheck
+//nolint:unused
 var mockQueryAdaptersSet = wire.NewSet(
 	mocks.NewFeedRepositoryMock,
 	wire.Bind(new(queries.FeedRepository), new(*mocks.FeedRepositoryMock)),
@@ -75,7 +75,7 @@ func newTxRepositoriesFactory(local identity.Public, logger logging.Logger, hmac
 	}
 }
 
-//nolint:deadcode,varcheck
+//nolint:unused
 var blobsAdaptersSet = wire.NewSet(
 	newFilesystemStorage,
 	wire.Bind(new(blobReplication.BlobStorage), new(*blobs.FilesystemStorage)),
@@ -89,7 +89,7 @@ func newFilesystemStorage(logger logging.Logger, config Config) (*blobs.Filesyst
 	return blobs.NewFilesystemStorage(path.Join(config.DataDirectory, "blobs"), logger)
 }
 
-//nolint:deadcode,varcheck
+//nolint:unused
 var adaptersSet = wire.NewSet(
 	adapters.NewCurrentTimeProvider,
 	wire.Bind(new(commands.CurrentTimeProvider), new(*adapters.CurrentTimeProvider)),

--- a/di/inject_application.go
+++ b/di/inject_application.go
@@ -9,7 +9,7 @@ import (
 	portsrpc "github.com/planetary-social/scuttlego/service/ports/rpc"
 )
 
-//nolint:deadcode,varcheck
+//nolint:unused
 var applicationSet = wire.NewSet(
 	wire.Struct(new(app.Application), "*"),
 

--- a/di/inject_config.go
+++ b/di/inject_config.go
@@ -8,7 +8,7 @@ import (
 	"github.com/planetary-social/scuttlego/service/domain/transport/boxstream"
 )
 
-//nolint:deadcode,varcheck
+//nolint:unused
 var extractFromConfigSet = wire.NewSet(
 	extractNetworkKeyFromConfig,
 	extractMessageHMACFromConfig,

--- a/di/inject_formats.go
+++ b/di/inject_formats.go
@@ -9,7 +9,7 @@ import (
 	"github.com/planetary-social/scuttlego/service/domain/feeds/formats"
 )
 
-//nolint:deadcode,varcheck
+//nolint:unused
 var formatsSet = wire.NewSet(
 	newFormats,
 

--- a/di/inject_ports.go
+++ b/di/inject_ports.go
@@ -13,7 +13,7 @@ import (
 	portsrpc "github.com/planetary-social/scuttlego/service/ports/rpc"
 )
 
-//nolint:deadcode,varcheck
+//nolint:unused
 var portsSet = wire.NewSet(
 	mux.NewMux,
 

--- a/di/inject_pubsub.go
+++ b/di/inject_pubsub.go
@@ -8,7 +8,7 @@ import (
 	"github.com/planetary-social/scuttlego/service/domain/transport/rpc"
 )
 
-//nolint:deadcode,varcheck
+//nolint:unused
 var pubSubSet = wire.NewSet(
 	requestPubSubSet,
 	messagePubSubSet,

--- a/service/adapters/mocks/blob_downloaded_pubsub.go
+++ b/service/adapters/mocks/blob_downloaded_pubsub.go
@@ -7,7 +7,6 @@ import (
 )
 
 type BlobDownloadedPubSubMock struct {
-	CallsCount int
 }
 
 func NewBlobDownloadedPubSubMock() *BlobDownloadedPubSubMock {
@@ -15,7 +14,6 @@ func NewBlobDownloadedPubSubMock() *BlobDownloadedPubSubMock {
 }
 
 func (b BlobDownloadedPubSubMock) Subscribe(ctx context.Context) <-chan queries.BlobDownloaded {
-	b.CallsCount++
 	ch := make(chan queries.BlobDownloaded)
 	close(ch)
 	return ch

--- a/service/domain/transport/rpc/connection_id.go
+++ b/service/domain/transport/rpc/connection_id.go
@@ -17,7 +17,9 @@ func (c ConnectionId) String() string {
 	return strconv.Itoa(c.id)
 }
 
-const connectionIdKey = "connection_id"
+type connectionIdKeyType string
+
+const connectionIdKey connectionIdKeyType = "connection_id"
 
 func PutConnectionIdInContext(ctx context.Context, id ConnectionId) context.Context {
 	return context.WithValue(ctx, connectionIdKey, id)


### PR DESCRIPTION
Linting problems fixed:
- fixed the comments ignoring certain lines
- removed incorrect assignment to an unused variable
- defined a separate type to avoid collisions when writing context values