### PR TITLE
Fix the way contact messages are handled

### DIFF
--- a/internal/set.go
+++ b/internal/set.go
@@ -1,0 +1,32 @@
+package internal
+
+type Set[T comparable] struct {
+	values map[T]struct{}
+}
+
+func NewSet[T comparable]() Set[T] {
+	return Set[T]{
+		values: make(map[T]struct{}),
+	}
+}
+
+func (s Set[T]) Contains(v T) bool {
+	_, ok := s.values[v]
+	return ok
+}
+
+func (s *Set[T]) Put(v T) {
+	s.values[v] = struct{}{}
+}
+
+func (s Set[T]) List() []T {
+	var result []T
+	for v := range s.values {
+		result = append(result, v)
+	}
+	return result
+}
+
+func (s Set[T]) Len() int {
+	return len(s.values)
+}

--- a/internal/set_test.go
+++ b/internal/set_test.go
@@ -1,0 +1,21 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSet(t *testing.T) {
+	s := NewSet[int]()
+
+	require.False(t, s.Contains(0))
+	require.Equal(t, 0, s.Len())
+	require.Len(t, s.List(), 0)
+
+	s.Put(0)
+
+	require.True(t, s.Contains(0))
+	require.Equal(t, 1, s.Len())
+	require.Equal(t, []int{0}, s.List())
+}

--- a/service/adapters/bolt/feed_repository.go
+++ b/service/adapters/bolt/feed_repository.go
@@ -2,12 +2,10 @@ package bolt
 
 import (
 	"encoding/binary"
-	"fmt"
 
 	"github.com/boreq/errors"
 	"github.com/planetary-social/scuttlego/service/adapters/bolt/utils"
 	"github.com/planetary-social/scuttlego/service/domain/feeds"
-	"github.com/planetary-social/scuttlego/service/domain/feeds/content"
 	"github.com/planetary-social/scuttlego/service/domain/feeds/formats"
 	"github.com/planetary-social/scuttlego/service/domain/feeds/message"
 	"github.com/planetary-social/scuttlego/service/domain/refs"
@@ -299,18 +297,9 @@ func (b FeedRepository) saveMessageInBucket(bucket *bbolt.Bucket, msg message.Me
 }
 
 func (b FeedRepository) saveContact(contact feeds.ContactToSave) error {
-	switch contact.Msg().Action() {
-	case content.ContactActionFollow:
-		return b.graph.Follow(contact.Who(), contact.Msg().Contact())
-	case content.ContactActionUnfollow:
-		return b.graph.Unfollow(contact.Who(), contact.Msg().Contact())
-	case content.ContactActionBlock:
-		return b.graph.Block(contact.Who(), contact.Msg().Contact())
-	case content.ContactActionUnblock:
-		return b.graph.Unblock(contact.Who(), contact.Msg().Contact())
-	default:
-		return fmt.Errorf("unknown contact action '%#v'", contact.Msg().Action())
-	}
+	return b.graph.UpdateContact(contact.Who(), contact.Msg().Contact(), func(c *feeds.Contact) error {
+		return c.Update(contact.Msg().Actions())
+	})
 }
 
 func messageKey(seq message.Sequence) []byte {

--- a/service/adapters/bolt/social_graph_repository_test.go
+++ b/service/adapters/bolt/social_graph_repository_test.go
@@ -101,7 +101,7 @@ func TestSocialGraphRepository_GetContacts(t *testing.T) {
 
 		contacts, err := txadapters.SocialGraphRepository.GetContacts(iden)
 		require.NoError(t, err)
-		sortAndCompareContacts(t,
+		sortAndRequireEqualContacts(t,
 			[]*feeds.Contact{
 				feeds.MustNewContactFromHistory(target1, true, false),
 				feeds.MustNewContactFromHistory(target2, true, false),
@@ -131,7 +131,7 @@ func TestSocialGraphRepository_GetContacts(t *testing.T) {
 
 		contacts, err := txadapters.SocialGraphRepository.GetContacts(iden)
 		require.NoError(t, err)
-		sortAndCompareContacts(
+		sortAndRequireEqualContacts(
 			t,
 			[]*feeds.Contact{
 				feeds.MustNewContactFromHistory(target1, true, true),
@@ -146,7 +146,7 @@ func TestSocialGraphRepository_GetContacts(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func sortAndCompareContacts(t *testing.T, a []*feeds.Contact, b []*feeds.Contact) {
+func sortAndRequireEqualContacts(t *testing.T, a []*feeds.Contact, b []*feeds.Contact) {
 	sort.Slice(a, func(i, j int) bool {
 		return a[i].Target().String() < a[j].Target().String()
 	})

--- a/service/adapters/bolt/social_graph_repository_test.go
+++ b/service/adapters/bolt/social_graph_repository_test.go
@@ -1,15 +1,17 @@
 package bolt_test
 
 import (
+	"sort"
 	"testing"
 
 	"github.com/planetary-social/scuttlego/di"
 	"github.com/planetary-social/scuttlego/fixtures"
+	"github.com/planetary-social/scuttlego/service/domain/feeds"
+	"github.com/planetary-social/scuttlego/service/domain/feeds/content"
+	"github.com/planetary-social/scuttlego/service/domain/refs"
 	"github.com/stretchr/testify/require"
 	"go.etcd.io/bbolt"
 )
-
-// todo more tests (eg. blocks should prevent get contects from returning values)
 
 func TestSocialGraphRepository_RemoveDropsContactDataForTheSpecifiedFeed(t *testing.T) {
 	db := fixtures.Bolt(t)
@@ -21,11 +23,8 @@ func TestSocialGraphRepository_RemoveDropsContactDataForTheSpecifiedFeed(t *test
 		txadapters, err := di.BuildTxTestAdapters(tx)
 		require.NoError(t, err)
 
-		err = txadapters.SocialGraphRepository.Follow(iden1, fixtures.SomeRefIdentity())
-		require.NoError(t, err)
-
-		err = txadapters.SocialGraphRepository.Follow(iden2, fixtures.SomeRefIdentity())
-		require.NoError(t, err)
+		applyContactAction(t, txadapters, iden1, fixtures.SomeRefIdentity(), content.ContactActionFollow)
+		applyContactAction(t, txadapters, iden2, fixtures.SomeRefIdentity(), content.ContactActionFollow)
 
 		return nil
 	})
@@ -71,6 +70,97 @@ func TestSocialGraphRepository_RemoveDropsContactDataForTheSpecifiedFeed(t *test
 		require.NotEmpty(t, contacts)
 
 		return nil
+	})
+	require.NoError(t, err)
+}
+
+func TestSocialGraphRepository_GetContacts(t *testing.T) {
+	db := fixtures.Bolt(t)
+
+	iden := fixtures.SomeRefIdentity()
+
+	target1 := fixtures.SomeRefIdentity()
+	target2 := fixtures.SomeRefIdentity()
+	target3 := fixtures.SomeRefIdentity()
+
+	err := db.Update(func(tx *bbolt.Tx) error {
+		txadapters, err := di.BuildTxTestAdapters(tx)
+		require.NoError(t, err)
+
+		applyContactAction(t, txadapters, iden, target1, content.ContactActionFollow)
+		applyContactAction(t, txadapters, iden, target2, content.ContactActionFollow)
+		applyContactAction(t, txadapters, iden, target3, content.ContactActionFollow)
+
+		return nil
+	})
+	require.NoError(t, err)
+
+	err = db.View(func(tx *bbolt.Tx) error {
+		txadapters, err := di.BuildTxTestAdapters(tx)
+		require.NoError(t, err)
+
+		contacts, err := txadapters.SocialGraphRepository.GetContacts(iden)
+		require.NoError(t, err)
+		sortAndCompareContacts(t,
+			[]*feeds.Contact{
+				feeds.MustNewContactFromHistory(target1, true, false),
+				feeds.MustNewContactFromHistory(target2, true, false),
+				feeds.MustNewContactFromHistory(target3, true, false),
+			},
+			contacts,
+		)
+
+		return nil
+	})
+	require.NoError(t, err)
+
+	err = db.Update(func(tx *bbolt.Tx) error {
+		txadapters, err := di.BuildTxTestAdapters(tx)
+		require.NoError(t, err)
+
+		applyContactAction(t, txadapters, iden, target1, content.ContactActionBlock)
+		applyContactAction(t, txadapters, iden, target2, content.ContactActionUnfollow)
+
+		return nil
+	})
+	require.NoError(t, err)
+
+	err = db.View(func(tx *bbolt.Tx) error {
+		txadapters, err := di.BuildTxTestAdapters(tx)
+		require.NoError(t, err)
+
+		contacts, err := txadapters.SocialGraphRepository.GetContacts(iden)
+		require.NoError(t, err)
+		sortAndCompareContacts(
+			t,
+			[]*feeds.Contact{
+				feeds.MustNewContactFromHistory(target1, true, true),
+				feeds.MustNewContactFromHistory(target2, false, false),
+				feeds.MustNewContactFromHistory(target3, true, false),
+			},
+			contacts,
+		)
+
+		return nil
+	})
+	require.NoError(t, err)
+}
+
+func sortAndCompareContacts(t *testing.T, a []*feeds.Contact, b []*feeds.Contact) {
+	sort.Slice(a, func(i, j int) bool {
+		return a[i].Target().String() < a[j].Target().String()
+	})
+
+	sort.Slice(b, func(i, j int) bool {
+		return b[i].Target().String() < b[j].Target().String()
+	})
+
+	require.Equal(t, a, b)
+}
+
+func applyContactAction(t *testing.T, txadapters di.TxTestAdapters, a refs.Identity, b refs.Identity, action content.ContactAction) {
+	err := txadapters.SocialGraphRepository.UpdateContact(a, b, func(contact *feeds.Contact) error {
+		return contact.Update(content.MustNewContactActions([]content.ContactAction{action}))
 	})
 	require.NoError(t, err)
 }

--- a/service/app/commands/handler_follow.go
+++ b/service/app/commands/handler_follow.go
@@ -38,7 +38,12 @@ func NewFollowHandler(
 }
 
 func (h *FollowHandler) Handle(cmd Follow) error {
-	contact, err := content.NewContact(cmd.Target, content.ContactActionFollow)
+	contactActions, err := content.NewContactActions([]content.ContactAction{content.ContactActionFollow})
+	if err != nil {
+		return errors.Wrap(err, "failed to create contact actions")
+	}
+
+	contact, err := content.NewContact(cmd.Target, contactActions)
 	if err != nil {
 		return errors.Wrap(err, "failed to create a contact message")
 	}

--- a/service/app/commands/handler_redeem_invite.go
+++ b/service/app/commands/handler_redeem_invite.go
@@ -71,7 +71,12 @@ func (h *RedeemInviteHandler) Handle(ctx context.Context, cmd RedeemInvite) erro
 	// todo publish contact and pub message?
 
 	// todo main feed or should the invite contain a feed ref?
-	follow, err := content.NewContact(cmd.Invite.Remote(), content.ContactActionFollow)
+	contactActions, err := content.NewContactActions([]content.ContactAction{content.ContactActionFollow})
+	if err != nil {
+		return errors.Wrap(err, "failed to create contact actions")
+	}
+
+	follow, err := content.NewContact(cmd.Invite.Remote(), contactActions)
 	if err != nil {
 		return errors.Wrap(err, "could not create a follow message")
 	}

--- a/service/domain/feeds/contact.go
+++ b/service/domain/feeds/contact.go
@@ -1,0 +1,78 @@
+package feeds
+
+import (
+	"fmt"
+
+	"github.com/boreq/errors"
+	"github.com/planetary-social/scuttlego/service/domain/feeds/content"
+	"github.com/planetary-social/scuttlego/service/domain/refs"
+)
+
+type Contact struct {
+	target    refs.Identity
+	following bool
+	blocking  bool
+}
+
+func NewContact(target refs.Identity) (*Contact, error) {
+	if target.IsZero() {
+		return nil, errors.New("zero value of target")
+	}
+	return &Contact{
+		target: target,
+	}, nil
+}
+
+func NewContactFromHistory(target refs.Identity, following, blocking bool) (*Contact, error) {
+	if target.IsZero() {
+		return nil, errors.New("zero value of target")
+	}
+	return &Contact{
+		target:    target,
+		following: following,
+		blocking:  blocking,
+	}, nil
+}
+
+func MustNewContactFromHistory(target refs.Identity, following, blocking bool) *Contact {
+	v, err := NewContactFromHistory(target, following, blocking)
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
+
+func (c *Contact) Update(actions content.ContactActions) error {
+	if actions.IsZero() {
+		return errors.New("zero value of actions")
+	}
+
+	for _, action := range actions.List() {
+		switch action {
+		case content.ContactActionFollow:
+			c.following = true
+		case content.ContactActionUnfollow:
+			c.following = false
+		case content.ContactActionBlock:
+			c.blocking = true
+		case content.ContactActionUnblock:
+			c.blocking = false
+		default:
+			return fmt.Errorf("unknown contact action '%#v'", action)
+		}
+	}
+
+	return nil
+}
+
+func (c *Contact) Target() refs.Identity {
+	return c.target
+}
+
+func (c *Contact) Following() bool {
+	return c.following
+}
+
+func (c *Contact) Blocking() bool {
+	return c.blocking
+}

--- a/service/domain/feeds/contact_test.go
+++ b/service/domain/feeds/contact_test.go
@@ -1,0 +1,109 @@
+package feeds_test
+
+import (
+	"testing"
+
+	"github.com/planetary-social/scuttlego/fixtures"
+	"github.com/planetary-social/scuttlego/service/domain/feeds"
+	"github.com/planetary-social/scuttlego/service/domain/feeds/content"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewContactFromHistory(t *testing.T) {
+	target := fixtures.SomeRefIdentity()
+
+	t.Run("following_true", func(t *testing.T) {
+		c, err := feeds.NewContactFromHistory(target, true, false)
+		require.NoError(t, err)
+
+		require.Equal(t, target, c.Target())
+		require.True(t, c.Following())
+		require.False(t, c.Blocking())
+	})
+
+	t.Run("following_false", func(t *testing.T) {
+		c, err := feeds.NewContactFromHistory(target, false, true)
+		require.NoError(t, err)
+
+		require.Equal(t, target, c.Target())
+		require.False(t, c.Following())
+		require.True(t, c.Blocking())
+	})
+}
+
+func TestContact_Update(t *testing.T) {
+	testCases := []struct {
+		Name      string
+		Actions   []content.ContactAction
+		Following bool
+		Blocking  bool
+	}{
+		{
+			Name: "follow",
+			Actions: []content.ContactAction{
+				content.ContactActionFollow,
+			},
+			Following: true,
+			Blocking:  false,
+		},
+		{
+			Name: "unfollow",
+			Actions: []content.ContactAction{
+				content.ContactActionUnfollow,
+			},
+			Following: false,
+			Blocking:  false,
+		},
+		{
+			Name: "block",
+			Actions: []content.ContactAction{
+				content.ContactActionBlock,
+			},
+			Following: false,
+			Blocking:  true,
+		},
+		{
+			Name: "unblock",
+			Actions: []content.ContactAction{
+				content.ContactActionUnblock,
+			},
+			Following: false,
+			Blocking:  false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			contact, err := feeds.NewContact(fixtures.SomeRefIdentity())
+			require.NoError(t, err)
+
+			err = contact.Update(content.MustNewContactActions(testCase.Actions))
+			require.NoError(t, err)
+
+			require.Equal(t, testCase.Following, contact.Following())
+			require.Equal(t, testCase.Blocking, contact.Blocking())
+		})
+	}
+}
+
+func TestContact_UpdateCorrectlyAppliesAllActions(t *testing.T) {
+	actions, err := content.NewContactActions(
+		[]content.ContactAction{
+			content.ContactActionUnfollow,
+			content.ContactActionUnblock,
+		},
+	)
+	require.NoError(t, err)
+
+	contact, err := feeds.NewContactFromHistory(fixtures.SomeRefIdentity(), true, true)
+	require.NoError(t, err)
+
+	require.True(t, contact.Following())
+	require.True(t, contact.Blocking())
+
+	err = contact.Update(actions)
+	require.NoError(t, err)
+
+	require.False(t, contact.Following())
+	require.False(t, contact.Blocking())
+}

--- a/service/domain/feeds/contact_test.go
+++ b/service/domain/feeds/contact_test.go
@@ -21,7 +21,7 @@ func TestNewContactFromHistory(t *testing.T) {
 		require.False(t, c.Blocking())
 	})
 
-	t.Run("following_false", func(t *testing.T) {
+	t.Run("blocking_true", func(t *testing.T) {
 		c, err := feeds.NewContactFromHistory(target, false, true)
 		require.NoError(t, err)
 

--- a/service/domain/feeds/content/contact.go
+++ b/service/domain/feeds/content/contact.go
@@ -1,32 +1,35 @@
 package content
 
 import (
+	"fmt"
+
 	"github.com/boreq/errors"
+	"github.com/planetary-social/scuttlego/internal"
 	"github.com/planetary-social/scuttlego/service/domain/refs"
 )
 
 type Contact struct {
 	contact refs.Identity
-	action  ContactAction
+	actions ContactActions
 }
 
-func NewContact(contact refs.Identity, action ContactAction) (Contact, error) {
+func NewContact(contact refs.Identity, actions ContactActions) (Contact, error) {
 	if contact.IsZero() {
 		return Contact{}, errors.New("zero value of contact")
 	}
 
-	if action.IsZero() {
-		return Contact{}, errors.New("zero value of feed")
+	if actions.IsZero() {
+		return Contact{}, errors.New("zero value of actions")
 	}
 
 	return Contact{
 		contact: contact,
-		action:  action,
+		actions: actions,
 	}, nil
 }
 
-func MustNewContact(contact refs.Identity, action ContactAction) Contact {
-	c, err := NewContact(contact, action)
+func MustNewContact(contact refs.Identity, actions ContactActions) Contact {
+	c, err := NewContact(contact, actions)
 	if err != nil {
 		panic(err)
 	}
@@ -41,8 +44,8 @@ func (c Contact) Contact() refs.Identity {
 	return c.contact
 }
 
-func (c Contact) Action() ContactAction {
-	return c.action
+func (c Contact) Actions() ContactActions {
+	return c.actions
 }
 
 type ContactAction struct {
@@ -59,3 +62,59 @@ var (
 	ContactActionBlock    = ContactAction{"block"}
 	ContactActionUnblock  = ContactAction{"unblock"}
 )
+
+type ContactActions struct {
+	actions internal.Set[ContactAction]
+}
+
+func NewContactActions(actions []ContactAction) (ContactActions, error) {
+	if len(actions) == 0 {
+		return ContactActions{}, errors.New("actions can not be empty")
+	}
+
+	m := internal.NewSet[ContactAction]()
+
+	for _, action := range actions {
+		if action.IsZero() {
+			return ContactActions{}, errors.New("zero value of action")
+		}
+
+		if m.Contains(action) {
+			return ContactActions{}, fmt.Errorf("duplicate action: '%s'", action)
+		}
+
+		m.Put(action)
+	}
+
+	if m.Contains(ContactActionFollow) && m.Contains(ContactActionUnfollow) {
+		return ContactActions{}, errors.New("both follow and unfollow are present")
+	}
+
+	if m.Contains(ContactActionBlock) && m.Contains(ContactActionUnblock) {
+		return ContactActions{}, errors.New("both block and unblock are present")
+	}
+
+	if m.Contains(ContactActionFollow) && m.Contains(ContactActionBlock) {
+		return ContactActions{}, errors.New("both follow and block are present")
+	}
+
+	return ContactActions{
+		actions: m,
+	}, nil
+}
+
+func MustNewContactActions(actions []ContactAction) ContactActions {
+	v, err := NewContactActions(actions)
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
+
+func (a *ContactActions) List() []ContactAction {
+	return a.actions.List()
+}
+
+func (a ContactActions) IsZero() bool {
+	return a.actions.Len() == 0
+}

--- a/service/domain/feeds/content/contact_test.go
+++ b/service/domain/feeds/content/contact_test.go
@@ -1,0 +1,95 @@
+package content
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/boreq/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestContactActions(t *testing.T) {
+	testCases := []struct {
+		Actions       []ContactAction
+		ExpectedError error
+	}{
+		{
+			Actions:       []ContactAction{},
+			ExpectedError: errors.New("actions can not be empty"),
+		},
+		{
+			Actions:       nil,
+			ExpectedError: errors.New("actions can not be empty"),
+		},
+		{
+			Actions: []ContactAction{
+				{},
+			},
+			ExpectedError: errors.New("zero value of action"),
+		},
+		{
+			Actions: []ContactAction{
+				ContactActionFollow,
+				ContactActionFollow,
+			},
+			ExpectedError: errors.New("duplicate action: '{follow}'"),
+		},
+		{
+			Actions: []ContactAction{
+				ContactActionFollow,
+			},
+			ExpectedError: nil,
+		},
+		{
+			Actions: []ContactAction{
+				ContactActionUnfollow,
+			},
+			ExpectedError: nil,
+		},
+		{
+			Actions: []ContactAction{
+				ContactActionBlock,
+			},
+			ExpectedError: nil,
+		},
+		{
+			Actions: []ContactAction{
+				ContactActionUnblock,
+			},
+			ExpectedError: nil,
+		},
+		{
+			Actions: []ContactAction{
+				ContactActionFollow,
+				ContactActionUnfollow,
+			},
+			ExpectedError: errors.New("both follow and unfollow are present"),
+		},
+		{
+			Actions: []ContactAction{
+				ContactActionBlock,
+				ContactActionUnblock,
+			},
+			ExpectedError: errors.New("both block and unblock are present"),
+		},
+		{
+			Actions: []ContactAction{
+				ContactActionFollow,
+				ContactActionBlock,
+			},
+			ExpectedError: errors.New("both follow and block are present"),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(fmt.Sprintf("%#v", testCase.Actions), func(t *testing.T) {
+			actions, err := NewContactActions(testCase.Actions)
+			if testCase.ExpectedError != nil {
+				require.EqualError(t, err, testCase.ExpectedError.Error())
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, len(testCase.Actions), len(actions.List()))
+			}
+		})
+	}
+}

--- a/service/domain/feeds/content/transport/mapping_contact.go
+++ b/service/domain/feeds/content/transport/mapping_contact.go
@@ -3,7 +3,6 @@ package transport
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/boreq/errors"
 	"github.com/planetary-social/scuttlego/internal"
@@ -90,42 +89,9 @@ func marshalContactActions(actions content.ContactActions, t *transportContact) 
 }
 
 type transportContact struct {
-	messageContentType // todo this is stupid
-	Contact            string
-	Following          *bool
-	Blocking           *bool
+	messageContentType        // todo this is stupid
+	Contact            string `json:"contact,omitempty"`
+	Following          *bool  `json:"following,omitempty"`
+	Blocking           *bool  `json:"blocking,omitempty"`
 	// todo pub field
-}
-
-// MarshalJSON implements custom logic which fixes the default behaviour of the
-// encoding/json package which treats nil pointers and pointers to zero values
-// in the same way when omitempty is specified. For example normally both a bool
-// pointer which is nil and a bool pointer which is set to false will not appear
-// in resulting JSON when omitempty is used.
-//
-// I think this code is disgusting so if someone can write this in a nicer way
-// please submit a pull request.
-func (t transportContact) MarshalJSON() ([]byte, error) {
-	pairs := []string{
-		`"type":"contact"`,
-		fmt.Sprintf(`"contact":"%s"`, t.Contact),
-	}
-
-	if t.Following != nil {
-		v, err := json.Marshal(t.Following)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to marshal following")
-		}
-		pairs = append(pairs, fmt.Sprintf(`"following":%s`, string(v)))
-	}
-
-	if t.Blocking != nil {
-		v, err := json.Marshal(t.Blocking)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to marshal blocking")
-		}
-		pairs = append(pairs, fmt.Sprintf(`"blocking":%s`, string(v)))
-	}
-
-	return []byte("{" + strings.Join(pairs, ",") + "}"), nil
 }

--- a/service/domain/feeds/content/transport/mapping_contact_test.go
+++ b/service/domain/feeds/content/transport/mapping_contact_test.go
@@ -3,6 +3,7 @@ package transport_test
 import (
 	"testing"
 
+	"github.com/boreq/errors"
 	msgcontents "github.com/planetary-social/scuttlego/service/domain/feeds/content"
 	"github.com/planetary-social/scuttlego/service/domain/feeds/message"
 	"github.com/planetary-social/scuttlego/service/domain/refs"
@@ -10,42 +11,214 @@ import (
 )
 
 func TestMappingContactUnmarshal(t *testing.T) {
-	marshaler := newMarshaler(t)
-
-	content := `
+	testCases := []struct {
+		Name            string
+		Content         string
+		ExpectedActions []msgcontents.ContactAction
+		ExpectedError   error
+	}{
+		{
+			Name: "missing_action",
+			Content: `
+{
+	"type": "contact",
+	"contact": "@sxlUkN7dW/qZ23Wid6J1IAnqWEJ3V13dT6TaFtn5LTc=.ed25519"
+}`,
+			ExpectedError: errors.New("mapping 'contact' returned an error: could not unmarshal contact action: actions can not be empty"),
+		},
+		{
+			Name: "following",
+			Content: `
 {
 	"type": "contact",
 	"contact": "@sxlUkN7dW/qZ23Wid6J1IAnqWEJ3V13dT6TaFtn5LTc=.ed25519",
 	"following": true
-}`
+}`,
+			ExpectedActions: []msgcontents.ContactAction{
+				msgcontents.ContactActionFollow,
+			},
+		},
+		{
+			Name: "unfollowing",
+			Content: `
+{
+	"type": "contact",
+	"contact": "@sxlUkN7dW/qZ23Wid6J1IAnqWEJ3V13dT6TaFtn5LTc=.ed25519",
+	"following": false
+}`,
+			ExpectedActions: []msgcontents.ContactAction{
+				msgcontents.ContactActionUnfollow,
+			},
+		},
+		{
+			Name: "blocking",
+			Content: `
+{
+	"type": "contact",
+	"contact": "@sxlUkN7dW/qZ23Wid6J1IAnqWEJ3V13dT6TaFtn5LTc=.ed25519",
+	"blocking": true
+}`,
+			ExpectedActions: []msgcontents.ContactAction{
+				msgcontents.ContactActionBlock,
+			},
+		},
+		{
+			Name: "unblocking",
+			Content: `
+{
+	"type": "contact",
+	"contact": "@sxlUkN7dW/qZ23Wid6J1IAnqWEJ3V13dT6TaFtn5LTc=.ed25519",
+	"blocking": false
+}`,
+			ExpectedActions: []msgcontents.ContactAction{
+				msgcontents.ContactActionUnblock,
+			},
+		},
+		{
+			Name: "following_and_unblocking",
+			Content: `
+{
+	"type": "contact",
+	"contact": "@sxlUkN7dW/qZ23Wid6J1IAnqWEJ3V13dT6TaFtn5LTc=.ed25519",
+	"following": true,
+	"blocking": false
+}`,
+			ExpectedActions: []msgcontents.ContactAction{
+				msgcontents.ContactActionFollow,
+				msgcontents.ContactActionUnblock,
+			},
+		},
+		{
+			Name: "unfollowing_and_blocking",
+			Content: `
+{
+	"type": "contact",
+	"contact": "@sxlUkN7dW/qZ23Wid6J1IAnqWEJ3V13dT6TaFtn5LTc=.ed25519",
+	"following": false,
+	"blocking": true
+}`,
+			ExpectedActions: []msgcontents.ContactAction{
+				msgcontents.ContactActionUnfollow,
+				msgcontents.ContactActionBlock,
+			},
+		},
+		{
+			Name: "following_and_blocking",
+			Content: `
+{
+	"type": "contact",
+	"contact": "@sxlUkN7dW/qZ23Wid6J1IAnqWEJ3V13dT6TaFtn5LTc=.ed25519",
+	"following": true,
+	"blocking": true
+}`,
+			ExpectedError: errors.New("mapping 'contact' returned an error: could not unmarshal contact action: both follow and block are present"),
+		},
+		{
+			Name: "unfollowing_and_unblocking",
+			Content: `
+{
+	"type": "contact",
+	"contact": "@sxlUkN7dW/qZ23Wid6J1IAnqWEJ3V13dT6TaFtn5LTc=.ed25519",
+	"following": false,
+	"blocking": false
+}`,
+			ExpectedActions: []msgcontents.ContactAction{
+				msgcontents.ContactActionUnfollow,
+				msgcontents.ContactActionUnblock,
+			},
+		},
+	}
 
-	msg, err := marshaler.Unmarshal(message.MustNewRawMessageContent([]byte(content)))
-	require.NoError(t, err)
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			marshaler := newMarshaler(t)
 
-	require.Equal(
-		t,
-		msgcontents.MustNewContact(
-			refs.MustNewIdentity("@sxlUkN7dW/qZ23Wid6J1IAnqWEJ3V13dT6TaFtn5LTc=.ed25519"),
-			msgcontents.ContactActionFollow,
-		),
-		msg,
-	)
+			msg, err := marshaler.Unmarshal(message.MustNewRawMessageContent([]byte(testCase.Content)))
+			if testCase.ExpectedError != nil {
+				require.EqualError(t, err, testCase.ExpectedError.Error())
+			} else {
+				require.NoError(t, err)
+				require.Equal(
+					t,
+					msgcontents.MustNewContact(
+						refs.MustNewIdentity("@sxlUkN7dW/qZ23Wid6J1IAnqWEJ3V13dT6TaFtn5LTc=.ed25519"),
+						msgcontents.MustNewContactActions(testCase.ExpectedActions),
+					),
+					msg,
+				)
+			}
+		})
+	}
 }
 
 func TestMappingContactMarshal(t *testing.T) {
-	marshaler := newMarshaler(t)
+	iden := refs.MustNewIdentity("@sxlUkN7dW/qZ23Wid6J1IAnqWEJ3V13dT6TaFtn5LTc=.ed25519")
 
-	msg := msgcontents.MustNewContact(
-		refs.MustNewIdentity("@sxlUkN7dW/qZ23Wid6J1IAnqWEJ3V13dT6TaFtn5LTc=.ed25519"),
-		msgcontents.ContactActionFollow,
-	)
+	testCases := []struct {
+		Name            string
+		Actions         []msgcontents.ContactAction
+		ExpectedContent string
+	}{
+		{
+			Name: "following",
+			Actions: []msgcontents.ContactAction{
+				msgcontents.ContactActionFollow,
+			},
+			ExpectedContent: `{"type":"contact","contact":"@sxlUkN7dW/qZ23Wid6J1IAnqWEJ3V13dT6TaFtn5LTc=.ed25519","following":true}`,
+		},
+		{
+			Name: "unfollowing",
+			Actions: []msgcontents.ContactAction{
+				msgcontents.ContactActionUnfollow,
+			},
+			ExpectedContent: `{"type":"contact","contact":"@sxlUkN7dW/qZ23Wid6J1IAnqWEJ3V13dT6TaFtn5LTc=.ed25519","following":false}`,
+		},
+		{
+			Name: "blocking",
+			Actions: []msgcontents.ContactAction{
+				msgcontents.ContactActionBlock,
+			},
+			ExpectedContent: `{"type":"contact","contact":"@sxlUkN7dW/qZ23Wid6J1IAnqWEJ3V13dT6TaFtn5LTc=.ed25519","blocking":true}`,
+		},
+		{
+			Name: "unblocking",
+			Actions: []msgcontents.ContactAction{
+				msgcontents.ContactActionUnblock,
+			},
+			ExpectedContent: `{"type":"contact","contact":"@sxlUkN7dW/qZ23Wid6J1IAnqWEJ3V13dT6TaFtn5LTc=.ed25519","blocking":false}`,
+		},
+		{
+			Name: "unfollowing_and_blocking",
+			Actions: []msgcontents.ContactAction{
+				msgcontents.ContactActionUnfollow,
+				msgcontents.ContactActionBlock,
+			},
+			ExpectedContent: `{"type":"contact","contact":"@sxlUkN7dW/qZ23Wid6J1IAnqWEJ3V13dT6TaFtn5LTc=.ed25519","following":false,"blocking":true}`,
+		},
+		{
+			Name: "following_and_unblocking",
+			Actions: []msgcontents.ContactAction{
+				msgcontents.ContactActionFollow,
+				msgcontents.ContactActionUnblock,
+			},
+			ExpectedContent: `{"type":"contact","contact":"@sxlUkN7dW/qZ23Wid6J1IAnqWEJ3V13dT6TaFtn5LTc=.ed25519","following":true,"blocking":false}`,
+		},
+	}
 
-	raw, err := marshaler.Marshal(msg)
-	require.NoError(t, err)
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			msg := msgcontents.MustNewContact(iden, msgcontents.MustNewContactActions(testCase.Actions))
 
-	require.Equal(
-		t,
-		`{"type":"contact","contact":"@sxlUkN7dW/qZ23Wid6J1IAnqWEJ3V13dT6TaFtn5LTc=.ed25519","following":true,"blocking":false}`,
-		string(raw.Bytes()),
-	)
+			marshaler := newMarshaler(t)
+
+			raw, err := marshaler.Marshal(msg)
+			require.NoError(t, err)
+
+			require.Equal(
+				t,
+				testCase.ExpectedContent,
+				string(raw.Bytes()),
+			)
+		})
+	}
 }

--- a/service/domain/feeds/feed_test.go
+++ b/service/domain/feeds/feed_test.go
@@ -196,14 +196,14 @@ func TestFeed_MessagesWithKnownContentAreCorrectlyRecognized(t *testing.T) {
 			Name: "contact",
 			Content: msgcontents.MustNewContact(
 				someIdentity,
-				msgcontents.ContactActionFollow,
+				msgcontents.MustNewContactActions([]msgcontents.ContactAction{msgcontents.ContactActionFollow}),
 			),
 			ExpectedContacts: []feeds.ContactToSave{
 				feeds.NewContactToSave(
 					authorId,
 					msgcontents.MustNewContact(
 						someIdentity,
-						msgcontents.ContactActionFollow,
+						msgcontents.MustNewContactActions([]msgcontents.ContactAction{msgcontents.ContactActionFollow}),
 					),
 				),
 			},

--- a/service/domain/graph/graph_test.go
+++ b/service/domain/graph/graph_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/planetary-social/scuttlego/fixtures"
+	"github.com/planetary-social/scuttlego/service/domain/feeds"
 	"github.com/planetary-social/scuttlego/service/domain/graph"
 	"github.com/planetary-social/scuttlego/service/domain/refs"
 	"github.com/stretchr/testify/require"
@@ -17,15 +18,15 @@ func TestContacts(t *testing.T) {
 	c := fixtures.SomeRefIdentity()
 
 	s := StorageMock{
-		contacts: map[string][]refs.Identity{
+		contacts: map[string][]*feeds.Contact{
 			local.String(): {
-				a,
+				feeds.MustNewContactFromHistory(a, true, false),
 			},
 			a.String(): {
-				b,
+				feeds.MustNewContactFromHistory(b, true, false),
 			},
 			b.String(): {
-				c,
+				feeds.MustNewContactFromHistory(c, true, false),
 			},
 		},
 	}
@@ -59,9 +60,9 @@ func TestContacts(t *testing.T) {
 }
 
 type StorageMock struct {
-	contacts map[string][]refs.Identity
+	contacts map[string][]*feeds.Contact
 }
 
-func (s StorageMock) GetContacts(node refs.Identity) ([]refs.Identity, error) {
+func (s StorageMock) GetContacts(node refs.Identity) ([]*feeds.Contact, error) {
 	return s.contacts[node.String()], nil
 }


### PR DESCRIPTION
Contact messages are now correctly parsed and interpreted. Each contact message is treated as a set of actions which should be performed on a contact such as:
  - follow a target
  - unfollow a target
  - block a target
  - unblock a target

One contact message can contain multiple actions eg. block and unfollow. Follow/unfollow are governed by field "following". Block/unblock are governed by field "blocking". Fields are mapped as follows:
- following == nil   => []
- following == true  => [follow]
- following == false => [unfollow]
- blocking  == nil   => []
- blocking  == true  => [block]
- blocking  == false => [unblock]

Updates are therefore atomic eg. a message may update one field but leave the other field untouched.

Some combinations of actions are logically suspicious eg. follow and block and are treated as errors for now. Message with no actions is treated as an error.

Based on this each contact effectively has two separate states which are tracked: whether it is followed and whether it is blocked. This was the case previously as well but the fields weren't correctly updated.

For example:
    Applying the block operation to contact(following=true, blocking=false)
Results in:
    contact(following=true, blocking=true)

Those fields are not correctly used when building the social graph yet but they are persisted and updated correctly now.