### PR TITLE
Change contacts so that author can't be the target

### DIFF
--- a/service/adapters/bolt/social_graph_repository.go
+++ b/service/adapters/bolt/social_graph_repository.go
@@ -43,7 +43,7 @@ func (s *SocialGraphRepository) UpdateContact(author, target refs.Identity, f Up
 	key := s.key(target)
 	value := bucket.Get(key)
 
-	contact, err := s.loadOrCreateContact(target, value)
+	contact, err := s.loadOrCreateContact(author, target, value)
 	if err != nil {
 		return errors.Wrap(err, "failed to load the existing contact")
 	}
@@ -82,7 +82,7 @@ func (s *SocialGraphRepository) GetContacts(node refs.Identity) ([]*feeds.Contac
 			return errors.Wrap(err, "could not create contact ref")
 		}
 
-		contact, err := s.loadContact(targetRef, v)
+		contact, err := s.loadContact(node, targetRef, v)
 		if err != nil {
 			return errors.Wrap(err, "failed to load the contact")
 		}
@@ -97,19 +97,19 @@ func (s *SocialGraphRepository) GetContacts(node refs.Identity) ([]*feeds.Contac
 	return result, nil
 }
 
-func (s *SocialGraphRepository) loadOrCreateContact(target refs.Identity, storedValue []byte) (*feeds.Contact, error) {
+func (s *SocialGraphRepository) loadOrCreateContact(author, target refs.Identity, storedValue []byte) (*feeds.Contact, error) {
 	if storedValue != nil {
-		return s.loadContact(target, storedValue)
+		return s.loadContact(author, target, storedValue)
 	}
-	return feeds.NewContact(target)
+	return feeds.NewContact(author, target)
 }
 
-func (s *SocialGraphRepository) loadContact(target refs.Identity, storedValue []byte) (*feeds.Contact, error) {
+func (s *SocialGraphRepository) loadContact(author, target refs.Identity, storedValue []byte) (*feeds.Contact, error) {
 	var c storedContact
 	if err := json.Unmarshal(storedValue, &c); err != nil {
 		return nil, errors.Wrap(err, "failed to unmarshal the existing value")
 	}
-	return feeds.NewContactFromHistory(target, c.Following, c.Blocking)
+	return feeds.NewContactFromHistory(author, target, c.Following, c.Blocking)
 }
 
 func (s *SocialGraphRepository) createFeedBucket(ref refs.Identity) (*bbolt.Bucket, error) {

--- a/service/adapters/bolt/social_graph_repository_test.go
+++ b/service/adapters/bolt/social_graph_repository_test.go
@@ -103,9 +103,9 @@ func TestSocialGraphRepository_GetContacts(t *testing.T) {
 		require.NoError(t, err)
 		sortAndRequireEqualContacts(t,
 			[]*feeds.Contact{
-				feeds.MustNewContactFromHistory(target1, true, false),
-				feeds.MustNewContactFromHistory(target2, true, false),
-				feeds.MustNewContactFromHistory(target3, true, false),
+				feeds.MustNewContactFromHistory(iden, target1, true, false),
+				feeds.MustNewContactFromHistory(iden, target2, true, false),
+				feeds.MustNewContactFromHistory(iden, target3, true, false),
 			},
 			contacts,
 		)
@@ -134,9 +134,9 @@ func TestSocialGraphRepository_GetContacts(t *testing.T) {
 		sortAndRequireEqualContacts(
 			t,
 			[]*feeds.Contact{
-				feeds.MustNewContactFromHistory(target1, true, true),
-				feeds.MustNewContactFromHistory(target2, false, false),
-				feeds.MustNewContactFromHistory(target3, true, false),
+				feeds.MustNewContactFromHistory(iden, target1, true, true),
+				feeds.MustNewContactFromHistory(iden, target2, false, false),
+				feeds.MustNewContactFromHistory(iden, target3, true, false),
 			},
 			contacts,
 		)

--- a/service/domain/feeds/contact.go
+++ b/service/domain/feeds/contact.go
@@ -9,33 +9,40 @@ import (
 )
 
 type Contact struct {
+	author    refs.Identity
 	target    refs.Identity
 	following bool
 	blocking  bool
 }
 
-func NewContact(target refs.Identity) (*Contact, error) {
+func NewContact(author, target refs.Identity) (*Contact, error) {
+	if author.IsZero() {
+		return nil, errors.New("zero value of author")
+	}
 	if target.IsZero() {
 		return nil, errors.New("zero value of target")
 	}
+	if author.Equal(target) {
+		return nil, errors.New("author can't be the same as target")
+	}
 	return &Contact{
+		author: author,
 		target: target,
 	}, nil
 }
 
-func NewContactFromHistory(target refs.Identity, following, blocking bool) (*Contact, error) {
-	if target.IsZero() {
-		return nil, errors.New("zero value of target")
+func NewContactFromHistory(author, target refs.Identity, following, blocking bool) (*Contact, error) {
+	c, err := NewContact(author, target)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to call the constructor")
 	}
-	return &Contact{
-		target:    target,
-		following: following,
-		blocking:  blocking,
-	}, nil
+	c.following = following
+	c.blocking = blocking
+	return c, nil
 }
 
-func MustNewContactFromHistory(target refs.Identity, following, blocking bool) *Contact {
-	v, err := NewContactFromHistory(target, following, blocking)
+func MustNewContactFromHistory(author, contact refs.Identity, following, blocking bool) *Contact {
+	v, err := NewContactFromHistory(author, contact, following, blocking)
 	if err != nil {
 		panic(err)
 	}

--- a/service/domain/feeds/contact_test.go
+++ b/service/domain/feeds/contact_test.go
@@ -9,11 +9,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestContact_AuthorCanNotBeTheSameAsTarget(t *testing.T) {
+	author := fixtures.SomeRefIdentity()
+
+	t.Run("new_contact", func(t *testing.T) {
+		_, err := feeds.NewContact(author, author)
+		require.EqualError(t, err, "author can't be the same as target")
+	})
+
+	t.Run("new_contact_from_history", func(t *testing.T) {
+		_, err := feeds.NewContactFromHistory(author, author, fixtures.SomeBool(), fixtures.SomeBool())
+		require.EqualError(t, err, "failed to call the constructor: author can't be the same as target")
+	})
+}
+
 func TestNewContactFromHistory(t *testing.T) {
+	author := fixtures.SomeRefIdentity()
 	target := fixtures.SomeRefIdentity()
 
 	t.Run("following_true", func(t *testing.T) {
-		c, err := feeds.NewContactFromHistory(target, true, false)
+		c, err := feeds.NewContactFromHistory(author, target, true, false)
 		require.NoError(t, err)
 
 		require.Equal(t, target, c.Target())
@@ -22,7 +37,7 @@ func TestNewContactFromHistory(t *testing.T) {
 	})
 
 	t.Run("blocking_true", func(t *testing.T) {
-		c, err := feeds.NewContactFromHistory(target, false, true)
+		c, err := feeds.NewContactFromHistory(author, target, false, true)
 		require.NoError(t, err)
 
 		require.Equal(t, target, c.Target())
@@ -74,7 +89,10 @@ func TestContact_Update(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.Name, func(t *testing.T) {
-			contact, err := feeds.NewContact(fixtures.SomeRefIdentity())
+			contact, err := feeds.NewContact(
+				fixtures.SomeRefIdentity(),
+				fixtures.SomeRefIdentity(),
+			)
 			require.NoError(t, err)
 
 			err = contact.Update(content.MustNewContactActions(testCase.Actions))
@@ -95,7 +113,12 @@ func TestContact_UpdateCorrectlyAppliesAllActions(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	contact, err := feeds.NewContactFromHistory(fixtures.SomeRefIdentity(), true, true)
+	contact, err := feeds.NewContactFromHistory(
+		fixtures.SomeRefIdentity(),
+		fixtures.SomeRefIdentity(),
+		true,
+		true,
+	)
 	require.NoError(t, err)
 
 	require.True(t, contact.Following())

--- a/service/domain/graph/graph_test.go
+++ b/service/domain/graph/graph_test.go
@@ -21,13 +21,13 @@ func TestContacts_FolloweesAreAddedToTheGraphUpToCertainDepth(t *testing.T) {
 	s := StorageMock{
 		contacts: map[string][]*feeds.Contact{
 			local.String(): {
-				feeds.MustNewContactFromHistory(a, true, false),
+				feeds.MustNewContactFromHistory(local, a, true, false),
 			},
 			a.String(): {
-				feeds.MustNewContactFromHistory(b, true, false),
+				feeds.MustNewContactFromHistory(a, b, true, false),
 			},
 			b.String(): {
-				feeds.MustNewContactFromHistory(c, true, false),
+				feeds.MustNewContactFromHistory(b, c, true, false),
 			},
 		},
 	}
@@ -68,11 +68,11 @@ func TestContacts_SmallerNumberOfHopsTakesPriority(t *testing.T) {
 	s := StorageMock{
 		contacts: map[string][]*feeds.Contact{
 			local.String(): {
-				feeds.MustNewContactFromHistory(a, true, false),
-				feeds.MustNewContactFromHistory(b, true, false),
+				feeds.MustNewContactFromHistory(local, a, true, false),
+				feeds.MustNewContactFromHistory(local, b, true, false),
 			},
 			a.String(): {
-				feeds.MustNewContactFromHistory(b, true, false),
+				feeds.MustNewContactFromHistory(a, b, true, false),
 			},
 		},
 	}
@@ -111,13 +111,13 @@ func TestContacts_EdgesWhichAreBlockedOrNotSetAsFollowingAreNotFollowed(t *testi
 	s := StorageMock{
 		contacts: map[string][]*feeds.Contact{
 			local.String(): {
-				feeds.MustNewContactFromHistory(a, true, false),
+				feeds.MustNewContactFromHistory(local, a, true, false),
 			},
 			a.String(): {
-				feeds.MustNewContactFromHistory(b, true, false),
-				feeds.MustNewContactFromHistory(c, false, true),
-				feeds.MustNewContactFromHistory(d, false, false),
-				feeds.MustNewContactFromHistory(e, true, true),
+				feeds.MustNewContactFromHistory(a, b, true, false),
+				feeds.MustNewContactFromHistory(a, c, false, true),
+				feeds.MustNewContactFromHistory(a, d, false, false),
+				feeds.MustNewContactFromHistory(a, e, true, true),
 			},
 		},
 	}
@@ -156,17 +156,17 @@ func TestContacts_LocalBlockingTakesPriorityAndAlwaysExcludesFeeds(t *testing.T)
 	s := StorageMock{
 		contacts: map[string][]*feeds.Contact{
 			local.String(): {
-				feeds.MustNewContactFromHistory(a, true, false),
-				feeds.MustNewContactFromHistory(b, true, false),
-				feeds.MustNewContactFromHistory(c, false, true),
-				feeds.MustNewContactFromHistory(d, false, false),
-				feeds.MustNewContactFromHistory(e, true, true),
+				feeds.MustNewContactFromHistory(local, a, true, false),
+				feeds.MustNewContactFromHistory(local, b, true, false),
+				feeds.MustNewContactFromHistory(local, c, false, true),
+				feeds.MustNewContactFromHistory(local, d, false, false),
+				feeds.MustNewContactFromHistory(local, e, true, true),
 			},
 			a.String(): {
-				feeds.MustNewContactFromHistory(b, true, false),
-				feeds.MustNewContactFromHistory(c, true, false),
-				feeds.MustNewContactFromHistory(d, true, false),
-				feeds.MustNewContactFromHistory(e, true, false),
+				feeds.MustNewContactFromHistory(a, b, true, false),
+				feeds.MustNewContactFromHistory(a, c, true, false),
+				feeds.MustNewContactFromHistory(a, d, true, false),
+				feeds.MustNewContactFromHistory(a, e, true, false),
 			},
 		},
 	}


### PR DESCRIPTION
Author of a contact (person who it belongs to/who created it) can't be the same as the person that the contact is pointing at (target). If someone accidently blocked themselves this could create some weird behaviour with removing feeds.