### PR TITLE
Do not return a feed when updating it

### DIFF
--- a/service/adapters/bolt/feed_repository.go
+++ b/service/adapters/bolt/feed_repository.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/boreq/errors"
 	"github.com/planetary-social/scuttlego/service/adapters/bolt/utils"
+	"github.com/planetary-social/scuttlego/service/app/commands"
 	"github.com/planetary-social/scuttlego/service/domain/feeds"
 	"github.com/planetary-social/scuttlego/service/domain/feeds/formats"
 	"github.com/planetary-social/scuttlego/service/domain/feeds/message"
@@ -44,7 +45,7 @@ func NewFeedRepository(
 	}
 }
 
-func (b FeedRepository) UpdateFeed(ref refs.Feed, f func(feed *feeds.Feed) (*feeds.Feed, error)) error {
+func (b FeedRepository) UpdateFeed(ref refs.Feed, f commands.UpdateFeedFn) error {
 	feed, err := b.loadFeed(ref)
 	if err != nil {
 		return errors.Wrap(err, "could not load a feed")
@@ -54,8 +55,7 @@ func (b FeedRepository) UpdateFeed(ref refs.Feed, f func(feed *feeds.Feed) (*fee
 		feed = feeds.NewFeed(b.formatScuttlebutt)
 	}
 
-	feed, err = f(feed)
-	if err != nil {
+	if err = f(feed); err != nil {
 		return errors.Wrap(err, "provided function returned an error")
 	}
 

--- a/service/adapters/bolt/feed_repository_test.go
+++ b/service/adapters/bolt/feed_repository_test.go
@@ -36,11 +36,8 @@ func TestFeedRepository_DeleteFeed(t *testing.T) {
 		adapters, err := di.BuildTxTestAdapters(tx)
 		require.NoError(t, err)
 
-		err = adapters.FeedRepository.UpdateFeed(feedRef, func(feed *feeds.Feed) (*feeds.Feed, error) {
-			err := feed.AppendMessage(fixtures.SomeMessage(message.NewFirstSequence(), feedRef))
-			require.NoError(t, err)
-
-			return feed, nil
+		err = adapters.FeedRepository.UpdateFeed(feedRef, func(feed *feeds.Feed) error {
+			return feed.AppendMessage(fixtures.SomeMessage(message.NewFirstSequence(), feedRef))
 		})
 		require.NoError(t, err)
 

--- a/service/adapters/bolt/read_feed_repository_test.go
+++ b/service/adapters/bolt/read_feed_repository_test.go
@@ -3,7 +3,6 @@ package bolt_test
 import (
 	"testing"
 
-	"github.com/boreq/errors"
 	"github.com/planetary-social/scuttlego/di"
 	"github.com/planetary-social/scuttlego/fixtures"
 	"github.com/planetary-social/scuttlego/service/domain/feeds"
@@ -29,12 +28,8 @@ func TestReadFeedRepository_Count(t *testing.T) {
 		feedRef := fixtures.SomeRefFeed()
 		msg := fixtures.SomeMessage(message.NewFirstSequence(), feedRef)
 
-		return txadapters.FeedRepository.UpdateFeed(feedRef, func(feed *feeds.Feed) (*feeds.Feed, error) {
-			if err := feed.AppendMessage(msg); err != nil {
-				return nil, errors.Wrap(err, "failed to append message")
-			}
-
-			return feed, nil
+		return txadapters.FeedRepository.UpdateFeed(feedRef, func(feed *feeds.Feed) error {
+			return feed.AppendMessage(msg)
 		})
 	})
 	require.NoError(t, err)

--- a/service/app/commands/common.go
+++ b/service/app/commands/common.go
@@ -39,9 +39,12 @@ type Adapters struct {
 	WantList    WantListRepository
 }
 
+type UpdateFeedFn func(feed *feeds.Feed) error
+
 type FeedRepository interface {
-	// UpdateFeed updates the specified feed by calling the provided function on it. Feed is never nil.
-	UpdateFeed(ref refs.Feed, f func(feed *feeds.Feed) (*feeds.Feed, error)) error
+	// UpdateFeed updates the specified feed by calling the provided function on
+	// it. Feed is never nil.
+	UpdateFeed(ref refs.Feed, f UpdateFeedFn) error
 }
 
 type SocialGraphRepository interface {

--- a/service/app/commands/handler_follow.go
+++ b/service/app/commands/handler_follow.go
@@ -59,11 +59,11 @@ func (h *FollowHandler) Handle(cmd Follow) error {
 	}
 
 	return h.transaction.Transact(func(adapters Adapters) error {
-		return adapters.Feed.UpdateFeed(myRef.MainFeed(), func(feed *feeds.Feed) (*feeds.Feed, error) {
+		return adapters.Feed.UpdateFeed(myRef.MainFeed(), func(feed *feeds.Feed) error {
 			if _, err := feed.CreateMessage(content, time.Now(), h.local); err != nil {
-				return nil, errors.Wrap(err, "failed to create a message")
+				return errors.Wrap(err, "failed to create a message")
 			}
-			return feed, nil
+			return nil
 		})
 	})
 }

--- a/service/app/commands/handler_publish_raw.go
+++ b/service/app/commands/handler_publish_raw.go
@@ -43,13 +43,13 @@ func (h *PublishRawHandler) Handle(cmd PublishRaw) (refs.Message, error) {
 	var id refs.Message
 
 	if err := h.transaction.Transact(func(adapters Adapters) error {
-		return adapters.Feed.UpdateFeed(myRef.MainFeed(), func(feed *feeds.Feed) (*feeds.Feed, error) {
+		return adapters.Feed.UpdateFeed(myRef.MainFeed(), func(feed *feeds.Feed) error {
 			var err error
 			id, err = feed.CreateMessage(content, time.Now(), h.local)
 			if err != nil {
-				return nil, errors.Wrap(err, "failed to create a message")
+				return errors.Wrap(err, "failed to create a message")
 			}
-			return feed, nil
+			return nil
 		})
 	}); err != nil {
 		return refs.Message{}, errors.Wrap(err, "transaction failed")

--- a/service/app/commands/handler_redeem_invite.go
+++ b/service/app/commands/handler_redeem_invite.go
@@ -94,12 +94,11 @@ func (h *RedeemInviteHandler) Handle(ctx context.Context, cmd RedeemInvite) erro
 	}
 
 	if err := h.transaction.Transact(func(adapters Adapters) error {
-		if err := adapters.Feed.UpdateFeed(myRef.MainFeed(), func(feed *feeds.Feed) (*feeds.Feed, error) {
+		if err := adapters.Feed.UpdateFeed(myRef.MainFeed(), func(feed *feeds.Feed) error {
 			if _, err := feed.CreateMessage(followContent, time.Now(), h.local); err != nil {
-				return nil, errors.Wrap(err, "could not append a message")
+				return errors.Wrap(err, "could not append a message")
 			}
-
-			return feed, nil
+			return nil
 		}); err != nil {
 			return errors.Wrap(err, "failed to update the feed")
 		}

--- a/service/app/commands/message_buffer.go
+++ b/service/app/commands/message_buffer.go
@@ -132,13 +132,13 @@ func (m *MessageBuffer) persistTransaction(adapters Adapters, feedsToPersist fee
 			continue // do nothing as this contact is not in our social graph
 		}
 
-		if err := adapters.Feed.UpdateFeed(feedRef, func(feed *feeds.Feed) (*feeds.Feed, error) {
+		if err := adapters.Feed.UpdateFeed(feedRef, func(feed *feeds.Feed) error {
 			for _, msg := range msgs {
 				if err := feed.AppendMessage(msg); err != nil {
-					return nil, errors.Wrap(err, "could not append a message")
+					return errors.Wrap(err, "could not append a message")
 				}
 			}
-			return feed, nil
+			return nil
 		}); err != nil {
 			return errors.Wrapf(err, "failed to update the feed '%s'", feedRef)
 		}


### PR DESCRIPTION
It makes the interface confusing, after all the feed is always created for you and it is unclear why you would want to return a different feed struct.