### PR TITLE
Message buffer rework

### DIFF
--- a/di/wire.go
+++ b/di/wire.go
@@ -198,7 +198,6 @@ func BuildService(context.Context, identity.Private, Config) (Service, error) {
 		privateIdentityToPublicIdentity,
 
 		commands.NewMessageBuffer,
-		wire.Bind(new(gossip.MessageBuffer), new(*commands.MessageBuffer)),
 
 		portsSet,
 		applicationSet,

--- a/di/wire_gen.go
+++ b/di/wire_gen.go
@@ -279,7 +279,7 @@ func BuildService(contextContext context.Context, private identity.Private, conf
 	createHistoryStreamHandlerAdapter := ebt2.NewCreateHistoryStreamHandlerAdapter(createHistoryStreamHandler)
 	sessionRunner := ebt.NewSessionRunner(logger, rawMessageHandler, contactsCache, createHistoryStreamHandlerAdapter)
 	replicator := ebt.NewReplicator(sessionTracker, sessionRunner, logger)
-	manager := gossip.NewManager(logger, contactsCache, messageBuffer)
+	manager := gossip.NewManager(logger, contactsCache)
 	gossipReplicator, err := gossip.NewGossipReplicator(manager, rawMessageHandler, logger)
 	if err != nil {
 		return Service{}, err

--- a/service/adapters/bolt/read_contacts_repository.go
+++ b/service/adapters/bolt/read_contacts_repository.go
@@ -61,5 +61,9 @@ func (b ReadContactsRepository) getFeedState(repository *FeedRepository, feed re
 		}
 		return replication.FeedState{}, errors.Wrap(err, "could not get a feed")
 	}
-	return replication.NewFeedState(f.Sequence())
+	seq, ok := f.Sequence()
+	if !ok {
+		return replication.FeedState{}, errors.New("we got a feed so it can't be empty")
+	}
+	return replication.NewFeedState(seq)
 }

--- a/service/app/commands/message_buffer_test.go
+++ b/service/app/commands/message_buffer_test.go
@@ -1,0 +1,1 @@
+package commands

--- a/service/app/commands/message_buffer_test.go
+++ b/service/app/commands/message_buffer_test.go
@@ -1,1 +1,0 @@
-package commands

--- a/service/domain/feeds/feed.go
+++ b/service/domain/feeds/feed.go
@@ -126,8 +126,11 @@ func (f *Feed) createMessage(content message.RawMessageContent, timestamp time.T
 	}
 }
 
-func (f *Feed) Sequence() message.Sequence {
-	return f.lastMsg.Sequence() // todo can be nil
+func (f *Feed) Sequence() (message.Sequence, bool) {
+	if f.lastMsg == nil {
+		return message.Sequence{}, false
+	}
+	return f.lastMsg.Sequence(), true
 }
 
 func (f *Feed) PopForPersisting() []MessageToPersist {

--- a/service/domain/messagebuffer/buffer.go
+++ b/service/domain/messagebuffer/buffer.go
@@ -1,0 +1,124 @@
+package messagebuffer
+
+import (
+	"sort"
+	"time"
+
+	"github.com/boreq/errors"
+	"github.com/planetary-social/scuttlego/service/domain/feeds/message"
+	"github.com/planetary-social/scuttlego/service/domain/refs"
+)
+
+type FeedMessages struct {
+	feed     refs.Feed
+	messages []sortedMessage
+}
+
+func NewFeedMessages(feed refs.Feed) *FeedMessages {
+	return &FeedMessages{feed: feed}
+}
+
+func (m *FeedMessages) Add(t time.Time, msg message.Message) error {
+	if !msg.Feed().Equal(m.feed) {
+		return errors.New("incorrect feed")
+	}
+
+	m.messages = append(m.messages, sortedMessage{
+		Msg: msg,
+		T:   t,
+	})
+
+	if l := len(m.messages); l >= 2 {
+		last := l - 1
+		if !m.messages[last].Msg.Sequence().ComesAfter(m.messages[last-1].Msg.Sequence()) {
+			sort.Slice(m.messages, func(i, j int) bool {
+				return m.messages[j].Msg.Sequence().ComesAfter(m.messages[i].Msg.Sequence())
+			})
+		}
+	}
+
+	return nil
+}
+
+func (m *FeedMessages) RemoveOlderThan(t time.Time) {
+	for i := len(m.messages) - 1; i >= 0; i-- {
+		if m.messages[i].T.Before(t) {
+			m.messages = append(m.messages[:i], m.messages[i+1:]...)
+		}
+	}
+}
+
+func (m *FeedMessages) LeaveOnlyAfter(sequence message.Sequence) {
+	var foundIndex *int
+	for i, msg := range m.messages {
+		if !msg.Msg.Sequence().ComesAfter(sequence) {
+			tmp := i
+			foundIndex = &tmp
+		} else {
+			break
+		}
+	}
+
+	if foundIndex != nil {
+		m.messages = m.messages[*foundIndex+1:]
+	}
+}
+
+func (m *FeedMessages) Len() int {
+	return len(m.messages)
+}
+
+// ConsecutiveSliceStartingWith returns a slice of messages that have
+// consecutive sequence numbers. The first message in the slice has a sequence
+// number which comes directly after the provided sequence number. If the
+// provided sequence number is nil then the first element has a sequence number
+// equal to the output of message.NewFirstSequence. If those conditions can't be
+// satisfied an empty slice is returned.
+func (m *FeedMessages) ConsecutiveSliceStartingWith(seq *message.Sequence) []message.Message {
+	var result []message.Message
+
+	for _, v := range m.messages {
+		if seq != nil && !v.Msg.Sequence().ComesAfter(*seq) {
+			continue
+		}
+
+		if len(result) == 0 {
+			if seq == nil {
+				if !v.Msg.Sequence().IsFirst() {
+					return nil
+				}
+			} else {
+				if !seq.ComesDirectlyBefore(v.Msg.Sequence()) {
+					return nil
+				}
+			}
+		}
+
+		if l := len(result); l > 0 {
+			if !result[l-1].Sequence().ComesDirectlyBefore(v.Msg.Sequence()) {
+				break
+			}
+		}
+
+		result = append(result, v.Msg)
+	}
+
+	return result
+}
+
+func (m *FeedMessages) Sequences() []message.Sequence {
+	var sequences []message.Sequence
+	for _, msg := range m.messages {
+		sequences = append(sequences, msg.Msg.Sequence())
+	}
+	return sequences
+}
+
+func (m *FeedMessages) Feed() refs.Feed {
+	return m.feed
+}
+
+type sortedMessage struct {
+	Msg message.Message
+	T   time.Time
+}

--- a/service/domain/messagebuffer/buffer.go
+++ b/service/domain/messagebuffer/buffer.go
@@ -82,19 +82,17 @@ func (m *FeedMessages) ConsecutiveSliceStartingWith(seq *message.Sequence) []mes
 			continue
 		}
 
-		if len(result) == 0 {
+		if l := len(result); l == 0 {
 			if seq == nil {
 				if !v.Msg.Sequence().IsFirst() {
-					return nil
+					break
 				}
 			} else {
 				if !seq.ComesDirectlyBefore(v.Msg.Sequence()) {
-					return nil
+					break
 				}
 			}
-		}
-
-		if l := len(result); l > 0 {
+		} else {
 			if !result[l-1].Sequence().ComesDirectlyBefore(v.Msg.Sequence()) {
 				break
 			}

--- a/service/domain/messagebuffer/buffer_test.go
+++ b/service/domain/messagebuffer/buffer_test.go
@@ -1,0 +1,295 @@
+package messagebuffer_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/planetary-social/scuttlego/fixtures"
+	"github.com/planetary-social/scuttlego/internal"
+	"github.com/planetary-social/scuttlego/service/domain/feeds/message"
+	"github.com/planetary-social/scuttlego/service/domain/messagebuffer"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFeedMessages_AddingMessagesFromTheSameFeedSucceeds(t *testing.T) {
+	feed := fixtures.SomeRefFeed()
+
+	v := messagebuffer.NewFeedMessages(feed)
+
+	err := v.Add(fixtures.SomeTime(), fixtures.SomeMessage(fixtures.SomeSequence(), feed))
+	require.NoError(t, err)
+}
+
+func TestFeedMessages_AddingMessagesFromADifferentFeedFails(t *testing.T) {
+	feed1 := fixtures.SomeRefFeed()
+	feed2 := fixtures.SomeRefFeed()
+
+	v := messagebuffer.NewFeedMessages(feed1)
+
+	err := v.Add(fixtures.SomeTime(), fixtures.SomeMessage(fixtures.SomeSequence(), feed2))
+	require.EqualError(t, err, "incorrect feed")
+}
+
+func TestFeedMessages_LenUpdatesWhenAddingMessages(t *testing.T) {
+	feed := fixtures.SomeRefFeed()
+
+	v := messagebuffer.NewFeedMessages(feed)
+
+	require.Equal(t, 0, v.Len())
+
+	err := v.Add(fixtures.SomeTime(), fixtures.SomeMessage(fixtures.SomeSequence(), feed))
+	require.NoError(t, err)
+
+	err = v.Add(fixtures.SomeTime(), fixtures.SomeMessage(fixtures.SomeSequence(), feed))
+	require.NoError(t, err)
+
+	require.Equal(t, 2, v.Len())
+}
+
+func TestFeedMessages_RemoveOlderThanRemovesMessages(t *testing.T) {
+	feed := fixtures.SomeRefFeed()
+
+	tm := fixtures.SomeTime()
+
+	beforeTm1 := tm.Add(-1 * time.Second)
+	beforeTm2 := tm.Add(-2 * time.Second)
+	beforeTm3 := tm.Add(-3 * time.Second)
+
+	afterTm1 := tm.Add(1 * time.Second)
+	afterTm2 := tm.Add(2 * time.Second)
+
+	v := messagebuffer.NewFeedMessages(feed)
+
+	err := v.Add(beforeTm1, fixtures.SomeMessage(fixtures.SomeSequence(), feed))
+	require.NoError(t, err)
+
+	err = v.Add(beforeTm2, fixtures.SomeMessage(fixtures.SomeSequence(), feed))
+	require.NoError(t, err)
+
+	err = v.Add(beforeTm3, fixtures.SomeMessage(fixtures.SomeSequence(), feed))
+	require.NoError(t, err)
+
+	err = v.Add(afterTm1, fixtures.SomeMessage(fixtures.SomeSequence(), feed))
+	require.NoError(t, err)
+
+	err = v.Add(afterTm2, fixtures.SomeMessage(fixtures.SomeSequence(), feed))
+	require.NoError(t, err)
+
+	require.Equal(t, 5, v.Len())
+
+	v.RemoveOlderThan(tm)
+
+	require.Equal(t, 2, v.Len())
+}
+
+func TestFeedMessages_LeaveOnlyAfterDoesNothingWhenEmpty(t *testing.T) {
+	feed := fixtures.SomeRefFeed()
+	v := messagebuffer.NewFeedMessages(feed)
+	v.LeaveOnlyAfter(message.MustNewSequence(2))
+}
+
+func TestFeedMessages_LeaveOnlyAfterDoesNotBreakWhenLastMessageIsBeingRemoved(t *testing.T) {
+	feed := fixtures.SomeRefFeed()
+
+	v := messagebuffer.NewFeedMessages(feed)
+
+	err := v.Add(fixtures.SomeTime(), fixtures.SomeMessage(message.MustNewSequence(1), feed))
+	require.NoError(t, err)
+
+	v.LeaveOnlyAfter(message.MustNewSequence(1))
+	require.Equal(t, 0, v.Len())
+}
+
+func TestFeedMessages_LeaveOnlyAfterRemovesMessages(t *testing.T) {
+	feed := fixtures.SomeRefFeed()
+
+	v := messagebuffer.NewFeedMessages(feed)
+
+	err := v.Add(fixtures.SomeTime(), fixtures.SomeMessage(message.MustNewSequence(1), feed))
+	require.NoError(t, err)
+
+	err = v.Add(fixtures.SomeTime(), fixtures.SomeMessage(message.MustNewSequence(2), feed))
+	require.NoError(t, err)
+
+	err = v.Add(fixtures.SomeTime(), fixtures.SomeMessage(message.MustNewSequence(3), feed))
+	require.NoError(t, err)
+
+	require.Equal(t, 3, v.Len())
+
+	v.LeaveOnlyAfter(message.MustNewSequence(2))
+
+	require.Equal(t, 1, v.Len())
+	require.Equal(t,
+		[]message.Sequence{
+			message.MustNewSequence(3),
+		},
+		messagesToSequences(
+			v.ConsecutiveSliceStartingWith(internal.Ptr(message.MustNewSequence(2))),
+		),
+	)
+}
+
+func TestFeedMessages_ConsecutiveSliceStartingWith(t *testing.T) {
+	testCases := []struct {
+		Name             string
+		Seq              *message.Sequence
+		MessageSequences []message.Sequence
+		ExpectedResult   []message.Sequence
+	}{
+		{
+			Name:             "empty",
+			Seq:              nil,
+			MessageSequences: nil,
+			ExpectedResult:   nil,
+		},
+		{
+			Name: "nil_consecutive",
+			Seq:  nil,
+			MessageSequences: []message.Sequence{
+				message.MustNewSequence(1),
+				message.MustNewSequence(2),
+				message.MustNewSequence(3),
+			},
+			ExpectedResult: []message.Sequence{
+				message.MustNewSequence(1),
+				message.MustNewSequence(2),
+				message.MustNewSequence(3),
+			},
+		},
+		{
+			Name: "nil_not_consecutive",
+			Seq:  nil,
+			MessageSequences: []message.Sequence{
+				message.MustNewSequence(1),
+				message.MustNewSequence(2),
+
+				message.MustNewSequence(4),
+				message.MustNewSequence(5),
+			},
+			ExpectedResult: []message.Sequence{
+				message.MustNewSequence(1),
+				message.MustNewSequence(2),
+			},
+		},
+		{
+			Name: "nil_gap_at_the_start",
+			Seq:  nil,
+			MessageSequences: []message.Sequence{
+				message.MustNewSequence(2),
+				message.MustNewSequence(3),
+				message.MustNewSequence(4),
+			},
+			ExpectedResult: nil,
+		},
+
+		{
+			Name: "not_nil_consecutive",
+			Seq:  internal.Ptr(message.MustNewSequence(2)),
+			MessageSequences: []message.Sequence{
+				message.MustNewSequence(3),
+				message.MustNewSequence(4),
+				message.MustNewSequence(5),
+			},
+			ExpectedResult: []message.Sequence{
+				message.MustNewSequence(3),
+				message.MustNewSequence(4),
+				message.MustNewSequence(5),
+			},
+		},
+		{
+			Name: "not_nil_not_consecutive",
+			Seq:  internal.Ptr(message.MustNewSequence(2)),
+			MessageSequences: []message.Sequence{
+				message.MustNewSequence(3),
+				message.MustNewSequence(4),
+
+				message.MustNewSequence(6),
+				message.MustNewSequence(7),
+			},
+			ExpectedResult: []message.Sequence{
+				message.MustNewSequence(3),
+				message.MustNewSequence(4),
+			},
+		},
+		{
+			Name: "nil_gap_at_the_start",
+			Seq:  internal.Ptr(message.MustNewSequence(2)),
+			MessageSequences: []message.Sequence{
+				message.MustNewSequence(4),
+				message.MustNewSequence(5),
+				message.MustNewSequence(6),
+			},
+			ExpectedResult: nil,
+		},
+
+		{
+			Name: "discard_starting_not_nil_consecutive",
+			Seq:  internal.Ptr(message.MustNewSequence(2)),
+			MessageSequences: []message.Sequence{
+				message.MustNewSequence(1),
+				message.MustNewSequence(2),
+				message.MustNewSequence(3),
+				message.MustNewSequence(4),
+				message.MustNewSequence(5),
+			},
+			ExpectedResult: []message.Sequence{
+				message.MustNewSequence(3),
+				message.MustNewSequence(4),
+				message.MustNewSequence(5),
+			},
+		},
+		{
+			Name: "discard_starting_not_nil_not_consecutive",
+			Seq:  internal.Ptr(message.MustNewSequence(2)),
+			MessageSequences: []message.Sequence{
+				message.MustNewSequence(1),
+				message.MustNewSequence(2),
+				message.MustNewSequence(3),
+				message.MustNewSequence(4),
+
+				message.MustNewSequence(6),
+				message.MustNewSequence(7),
+			},
+			ExpectedResult: []message.Sequence{
+				message.MustNewSequence(3),
+				message.MustNewSequence(4),
+			},
+		},
+		{
+			Name: "discard_starting_nil_gap_at_the_start",
+			Seq:  internal.Ptr(message.MustNewSequence(2)),
+			MessageSequences: []message.Sequence{
+				message.MustNewSequence(1),
+				message.MustNewSequence(2),
+				message.MustNewSequence(4),
+				message.MustNewSequence(5),
+				message.MustNewSequence(6),
+			},
+			ExpectedResult: nil,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			feed := fixtures.SomeRefFeed()
+			v := messagebuffer.NewFeedMessages(feed)
+
+			for _, seq := range testCase.MessageSequences {
+				err := v.Add(fixtures.SomeTime(), fixtures.SomeMessage(seq, feed))
+				require.NoError(t, err)
+			}
+
+			msgs := v.ConsecutiveSliceStartingWith(testCase.Seq)
+			require.Equal(t, testCase.ExpectedResult, messagesToSequences(msgs))
+		})
+	}
+
+}
+
+func messagesToSequences(msgs []message.Message) []message.Sequence {
+	var result []message.Sequence
+	for _, msg := range msgs {
+		result = append(result, msg.Sequence())
+	}
+	return result
+}

--- a/service/domain/messagebuffer/buffer_test.go
+++ b/service/domain/messagebuffer/buffer_test.go
@@ -85,7 +85,10 @@ func TestFeedMessages_RemoveOlderThanRemovesMessages(t *testing.T) {
 func TestFeedMessages_LeaveOnlyAfterDoesNothingWhenEmpty(t *testing.T) {
 	feed := fixtures.SomeRefFeed()
 	v := messagebuffer.NewFeedMessages(feed)
+
+	require.Equal(t, 0, v.Len())
 	v.LeaveOnlyAfter(message.MustNewSequence(2))
+	require.Equal(t, 0, v.Len())
 }
 
 func TestFeedMessages_LeaveOnlyAfterDoesNotBreakWhenLastMessageIsBeingRemoved(t *testing.T) {

--- a/service/domain/messagebuffer/buffer_test.go
+++ b/service/domain/messagebuffer/buffer_test.go
@@ -96,10 +96,14 @@ func TestFeedMessages_LeaveOnlyAfterDoesNotBreakWhenLastMessageIsBeingRemoved(t 
 
 	v := messagebuffer.NewFeedMessages(feed)
 
-	err := v.Add(fixtures.SomeTime(), fixtures.SomeMessage(message.MustNewSequence(1), feed))
+	sequence1 := message.MustNewSequence(1)
+	sequence2 := message.MustNewSequence(10)
+	require.GreaterOrEqual(t, sequence1.Int(), sequence1.Int())
+
+	err := v.Add(fixtures.SomeTime(), fixtures.SomeMessage(sequence1, feed))
 	require.NoError(t, err)
 
-	v.LeaveOnlyAfter(message.MustNewSequence(1))
+	v.LeaveOnlyAfter(sequence2)
 	require.Equal(t, 0, v.Len())
 }
 

--- a/service/domain/replication/ebt/session.go
+++ b/service/domain/replication/ebt/session.go
@@ -206,6 +206,7 @@ func (s *Session) handleIncomingMessage(ctx context.Context, incoming IncomingMe
 	msg, ok := incoming.Msg()
 	if ok {
 		if err := s.rawMessageHandler.Handle(msg); err != nil {
+			// todo ban this feed somehow
 			return errors.Wrap(err, "error handling a message")
 		}
 		return nil


### PR DESCRIPTION
Message buffer can now handle messages arriving out of order from many
peers. Dropped the optimization which took buffer state into account as
this whole mechanism will probably need rework anyway and was
malfunctioning.