### PR TITLE
Author of a contact can be the same as its target

### DIFF
--- a/service/domain/feeds/contact.go
+++ b/service/domain/feeds/contact.go
@@ -22,9 +22,6 @@ func NewContact(author, target refs.Identity) (*Contact, error) {
 	if target.IsZero() {
 		return nil, errors.New("zero value of target")
 	}
-	if author.Equal(target) {
-		return nil, errors.New("author can't be the same as target")
-	}
 	return &Contact{
 		author: author,
 		target: target,

--- a/service/domain/feeds/contact_test.go
+++ b/service/domain/feeds/contact_test.go
@@ -9,17 +9,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestContact_AuthorCanNotBeTheSameAsTarget(t *testing.T) {
+func TestContact_AuthorCanBeTheSameAsTarget(t *testing.T) {
 	author := fixtures.SomeRefIdentity()
 
 	t.Run("new_contact", func(t *testing.T) {
 		_, err := feeds.NewContact(author, author)
-		require.EqualError(t, err, "author can't be the same as target")
+		require.NoError(t, err)
 	})
 
 	t.Run("new_contact_from_history", func(t *testing.T) {
 		_, err := feeds.NewContactFromHistory(author, author, fixtures.SomeBool(), fixtures.SomeBool())
-		require.EqualError(t, err, "failed to call the constructor: author can't be the same as target")
+		require.NoError(t, err)
 	})
 }
 


### PR DESCRIPTION
Some clients emit contact messages following their own feed for some
reason.