### PR TITLE
Don't return errors for mentions which are an object

### DIFF
--- a/service/domain/feeds/content/transport/mapping_post.go
+++ b/service/domain/feeds/content/transport/mapping_post.go
@@ -2,11 +2,9 @@ package transport
 
 import (
 	"encoding/json"
-	"strings"
 
 	"github.com/boreq/errors"
 	"github.com/planetary-social/scuttlego/service/domain/feeds/content"
-	"github.com/planetary-social/scuttlego/service/domain/refs"
 )
 
 var postMapping = MessageContentMapping{
@@ -20,23 +18,9 @@ var postMapping = MessageContentMapping{
 			return nil, errors.Wrap(err, "json unmarshal failed")
 		}
 
-		var blobs []refs.Blob
-		for _, rawJSON := range t.Mentions {
-			mention, err := unmarshalMention(rawJSON)
-			if err != nil {
-				return nil, errors.Wrap(err, "could not unmarshal a blob link")
-			}
-
-			if !strings.HasPrefix(mention.Link, "&") {
-				continue
-			}
-
-			blob, err := refs.NewBlob(mention.Link)
-			if err != nil {
-				return nil, errors.Wrap(err, "could not create a blob ref")
-			}
-
-			blobs = append(blobs, blob)
+		blobs, err := unmarshalMentions(t.Mentions)
+		if err != nil {
+			return nil, errors.Wrap(err, "could not unmarshal mentions")
 		}
 
 		return content.NewPost(blobs)
@@ -46,5 +30,5 @@ var postMapping = MessageContentMapping{
 type transportPost struct {
 	messageContentType // todo this is stupid
 
-	Mentions []json.RawMessage `json:"mentions"`
+	Mentions json.RawMessage `json:"mentions"`
 }

--- a/service/domain/feeds/content/transport/mapping_post_test.go
+++ b/service/domain/feeds/content/transport/mapping_post_test.go
@@ -20,6 +20,14 @@ func TestMappingPostUnmarshal(t *testing.T) {
 		ExpectedPost msgcontents.Post
 	}{
 		{
+			Name: "no_mentions",
+			Content: `{
+				"type": "post",
+				"text": "YES WE CAN! :heart: :smiley_cat:"
+			}`,
+			ExpectedPost: postWithoutBlobs,
+		},
+		{
 			Name: "complex",
 			Content: `{
 				"type": "post",
@@ -52,6 +60,17 @@ func TestMappingPostUnmarshal(t *testing.T) {
 				]
 			}`,
 			ExpectedPost: postWithoutBlobs,
+		},
+		{
+			Name: "mentions_which_are_a_map",
+			Content: `{
+				"type": "post",
+				"text": "a new photo from #dweb-camp 2022! ![photo.bmp](&O0h21NiGLLmjCF1kD2xWllvPExwe6t5P+F7YK3HAX4g=.sha256)",
+				"mentions": {
+					"0":{"name":"photo.bmp","type": "image/bmp"}
+				}
+			}`,
+			ExpectedPost: postWithoutBlobs, // todo probably actually scan the markdown
 		},
 	}
 

--- a/service/ports/pubsub/room_attendant_events_test.go
+++ b/service/ports/pubsub/room_attendant_events_test.go
@@ -43,7 +43,7 @@ func TestRoomAttendantEventSubscriber_ReceivesEventsAndCallsTheCommandHandler(t 
 	require.Eventually(t,
 		func() bool {
 			return assert.ObjectsAreEqual([]commands.ProcessRoomAttendantEvent{cmd}, handler.Calls())
-		}, 1*time.Second, 10*time.Millisecond)
+		}, 5*time.Second, 10*time.Millisecond)
 }
 
 type processRoomAttendantEventHandlerMock struct {

--- a/service/ports/pubsub/room_attendant_events_test.go
+++ b/service/ports/pubsub/room_attendant_events_test.go
@@ -34,6 +34,8 @@ func TestRoomAttendantEventSubscriber_ReceivesEventsAndCallsTheCommandHandler(t 
 	event, err := rooms.NewRoomAttendantsEvent(rooms.RoomAttendantsEventTypeJoined, fixtures.SomeRefIdentity())
 	require.NoError(t, err)
 
+	<-time.After(100 * time.Millisecond)
+
 	err = ps.PublishAttendantEvent(portal, event)
 	require.NoError(t, err)
 
@@ -43,7 +45,7 @@ func TestRoomAttendantEventSubscriber_ReceivesEventsAndCallsTheCommandHandler(t 
 	require.Eventually(t,
 		func() bool {
 			return assert.ObjectsAreEqual([]commands.ProcessRoomAttendantEvent{cmd}, handler.Calls())
-		}, 5*time.Second, 10*time.Millisecond)
+		}, 1*time.Second, 100*time.Millisecond)
 }
 
 type processRoomAttendantEventHandlerMock struct {


### PR DESCRIPTION
Partially related to https://github.com/planetary-social/scuttlego/issues/69.

Full fix probably involves actually scanning the markdown for links. It is unclear where this format is coming from and where it is specified.