### PR TITLE
Fix commands related to aliases

### DIFF
--- a/service/app/commands/handler_rooms_alias_register_test.go
+++ b/service/app/commands/handler_rooms_alias_register_test.go
@@ -98,3 +98,44 @@ func TestRoomsAliasRegisterHandler_RemoteTerminatesWithAnError(t *testing.T) {
 	_, err = c.RoomsAliasRegister.Handle(ctx, cmd)
 	require.EqualError(t, err, "could not contact the pub and redeem the invite: received an error: remote end")
 }
+
+func TestRoomsAliasRegisterHandler_RemoteTerminatesWithAnErrorBecauseAnAliasIsAlreadyTaken(t *testing.T) {
+	c, err := di.BuildTestCommands(t)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(fixtures.TestContext(t), 5*time.Second)
+	defer cancel()
+
+	roomIdentityRef := fixtures.SomeRefIdentity()
+	roomAddress := network.NewAddress(fixtures.SomeString())
+
+	alias := fixtures.SomeAlias()
+
+	connection := mocks.NewConnectionMock(ctx)
+	connection.Mock(
+		func(req *rpc.Request) []rpc.ResponseWithError {
+			require.Equal(t, messages.RoomRegisterAliasProcedure.Typ(), req.Type())
+			require.Equal(t, messages.RoomRegisterAliasProcedure.Name(), req.Name())
+			require.Contains(t, string(req.Arguments()), alias.String())
+
+			return []rpc.ResponseWithError{
+				{
+					Value: nil,
+					Err:   rpc.NewRemoteError([]byte(`{"name":"Error","message":"alias (\"alias\") is already taken","stack":""}`)),
+				},
+			}
+		},
+	)
+
+	c.Dialer.MockPeer(roomIdentityRef.Identity(), roomAddress, connection)
+
+	cmd, err := commands.NewRoomsAliasRegister(
+		roomIdentityRef,
+		roomAddress,
+		alias,
+	)
+	require.NoError(t, err)
+
+	_, err = c.RoomsAliasRegister.Handle(ctx, cmd)
+	require.ErrorIs(t, err, commands.ErrRoomAliasAlreadyTaken)
+}

--- a/service/app/commands/handler_rooms_alias_register_test.go
+++ b/service/app/commands/handler_rooms_alias_register_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestRoomsAliasRegisterHandler(t *testing.T) {
+func TestRoomsAliasRegisterHandler_RemoteReturnsSomeData(t *testing.T) {
 	c, err := di.BuildTestCommands(t)
 	require.NoError(t, err)
 
@@ -58,7 +58,7 @@ func TestRoomsAliasRegisterHandler(t *testing.T) {
 	require.Equal(t, expectedAliasString, aliasURL.String())
 }
 
-func TestRoomsAliasRegisterHandler_RemoteReturnsAnError(t *testing.T) {
+func TestRoomsAliasRegisterHandler_RemoteTerminatesWithAnError(t *testing.T) {
 	c, err := di.BuildTestCommands(t)
 	require.NoError(t, err)
 

--- a/service/app/commands/handler_rooms_alias_revoke.go
+++ b/service/app/commands/handler_rooms_alias_revoke.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/boreq/errors"
@@ -99,8 +98,8 @@ func (h *RoomsAliasRevokeHandler) Handle(ctx context.Context, cmd RoomsAliasRevo
 		return errors.New("channel closed")
 	}
 
-	if err := response.Err; !errors.Is(err, rpc.ErrRemoteEnd) {
-		return fmt.Errorf("received an unexpected error value: %s", err)
+	if err := response.Err; err != nil {
+		return errors.Wrap(err, "received an error")
 	}
 
 	return nil

--- a/service/app/commands/handler_rooms_alias_revoke_test.go
+++ b/service/app/commands/handler_rooms_alias_revoke_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestRoomsAliasRevokeHandler_RemoteReturnsUnexpectedData(t *testing.T) {
+func TestRoomsAliasRevokeHandler_RemoteReturnsSomeData(t *testing.T) {
 	c, err := di.BuildTestCommands(t)
 	require.NoError(t, err)
 
@@ -53,7 +53,7 @@ func TestRoomsAliasRevokeHandler_RemoteReturnsUnexpectedData(t *testing.T) {
 	require.NoError(t, err)
 
 	err = c.RoomsAliasRevoke.Handle(ctx, cmd)
-	require.EqualError(t, err, "received an unexpected error value: %!s(<nil>)")
+	require.NoError(t, err)
 }
 
 func TestRoomsAliasRevokeHandler_RemoteTerminatesWithAnError(t *testing.T) {
@@ -78,7 +78,7 @@ func TestRoomsAliasRevokeHandler_RemoteTerminatesWithAnError(t *testing.T) {
 			return []rpc.ResponseWithError{
 				{
 					Value: nil,
-					Err:   rpc.RemoteError{},
+					Err:   rpc.NewRemoteError(nil),
 				},
 			}
 		},
@@ -94,7 +94,7 @@ func TestRoomsAliasRevokeHandler_RemoteTerminatesWithAnError(t *testing.T) {
 	require.NoError(t, err)
 
 	err = c.RoomsAliasRevoke.Handle(ctx, cmd)
-	require.EqualError(t, err, "received an unexpected error value: remote returned an error")
+	require.EqualError(t, err, "received an error: remote returned an error")
 }
 
 func TestRoomsAliasRevokeHandler_RemoteTerminatesCleanly(t *testing.T) {
@@ -135,5 +135,5 @@ func TestRoomsAliasRevokeHandler_RemoteTerminatesCleanly(t *testing.T) {
 	require.NoError(t, err)
 
 	err = c.RoomsAliasRevoke.Handle(ctx, cmd)
-	require.NoError(t, err)
+	require.EqualError(t, err, "received an error: remote end")
 }


### PR DESCRIPTION
Async functions shouldn't terminate with an error.