### PR TITLE
Fix a duplex race condition

### DIFF
--- a/service/app/queries/create_history_stream.go
+++ b/service/app/queries/create_history_stream.go
@@ -117,7 +117,9 @@ func (h *CreateHistoryStreamHandler) worker(ctx context.Context) {
 			if closeErr := req.Query().ResponseWriter.CloseWithError(err); closeErr != nil {
 				h.logger.WithError(closeErr).Debug("closing failed")
 			}
-			h.logger.WithError(err).Error("error processing an incoming request")
+			if !errors.Is(err, context.Canceled) {
+				h.logger.WithError(err).Error("error processing an incoming request")
+			}
 		}
 	}
 }

--- a/service/domain/transport/rpc/connection_test.go
+++ b/service/domain/transport/rpc/connection_test.go
@@ -338,9 +338,6 @@ func TestIncomingRequests(t *testing.T) {
 	for i := range testCases {
 		testCase := testCases[i]
 		t.Run(testCase.Name, func(t *testing.T) {
-			if testCase.Name == "duplex" {
-				t.Skip("#109")
-			}
 			t.Parallel()
 
 			ctx := fixtures.TestContext(t)

--- a/service/domain/transport/rpc/request_stream_test.go
+++ b/service/domain/transport/rpc/request_stream_test.go
@@ -202,6 +202,16 @@ func TestRequestStream_HandleNewMessageReturnsAnErrorForProceduresThatAreNotDupl
 
 			msg := someDuplexIncomingMessage(t, requestNumber)
 
+			if testCase.AcceptsFollowUpMessages {
+				ch, err := stream.IncomingMessages()
+				require.NoError(t, err)
+
+				go func() {
+					for range ch {
+					}
+				}()
+			}
+
 			err = stream.HandleNewMessage(msg)
 			if testCase.AcceptsFollowUpMessages {
 				require.NoError(t, err)

--- a/service/domain/transport/rpc/request_streams_test.go
+++ b/service/domain/transport/rpc/request_streams_test.go
@@ -265,8 +265,6 @@ func TestRequestStreams_RemoteCanSendTerminationAfterTheStreamIsClosed(t *testin
 }
 
 func TestRequestStreams_MultipleMessagesSentInDuplexStream(t *testing.T) {
-	t.Skip("todo fix this test, there is a race condition in handling incoming messages and close messages in duplex streams #109")
-
 	t.Parallel()
 
 	requestNumber := fixtures.SomePositiveInt32()


### PR DESCRIPTION
A sequence of in-stream messages and then a remote termination could cause the last of the in-stream messages to be lost due to a race condition.