### PR TITLE
Cleanup application struct

### DIFF
--- a/di/inject_application.go
+++ b/di/inject_application.go
@@ -7,6 +7,7 @@ import (
 	"github.com/planetary-social/scuttlego/service/app/commands"
 	"github.com/planetary-social/scuttlego/service/app/queries"
 	"github.com/planetary-social/scuttlego/service/domain/replication"
+	"github.com/planetary-social/scuttlego/service/ports/network"
 	"github.com/planetary-social/scuttlego/service/ports/pubsub"
 	portsrpc "github.com/planetary-social/scuttlego/service/ports/rpc"
 )
@@ -26,12 +27,23 @@ var commandsSet = wire.NewSet(
 	commands.NewFollowHandler,
 	commands.NewConnectHandler,
 	commands.NewDisconnectAllHandler,
-	commands.NewAcceptNewPeerHandler,
-	commands.NewProcessNewLocalDiscoveryHandler,
 	commands.NewPublishRawHandler,
-	commands.NewEstablishNewConnectionsHandler,
 	commands.NewDownloadBlobHandler,
 	commands.NewCreateBlobHandler,
+	commands.NewDownloadFeedHandler,
+	commands.NewRoomsAliasRegisterHandler,
+	commands.NewRoomsAliasRevokeHandler,
+	commands.NewAddToBanListHandler,
+	commands.NewRemoveFromBanListHandler,
+
+	commands.NewProcessNewLocalDiscoveryHandler,
+	wire.Bind(new(network.ProcessNewLocalDiscoveryCommandHandler), new(*commands.ProcessNewLocalDiscoveryHandler)),
+
+	commands.NewAcceptNewPeerHandler,
+	wire.Bind(new(network.AcceptNewPeerCommandHandler), new(*commands.AcceptNewPeerHandler)),
+
+	commands.NewEstablishNewConnectionsHandler,
+	wire.Bind(new(network.EstablishNewConnectionsCommandHandler), new(*commands.EstablishNewConnectionsHandler)),
 
 	commands.NewRawMessageHandler,
 	wire.Bind(new(replication.RawMessageHandler), new(*commands.RawMessageHandler)),
@@ -39,19 +51,11 @@ var commandsSet = wire.NewSet(
 	commands.NewCreateWantsHandler,
 	wire.Bind(new(portsrpc.CreateWantsCommandHandler), new(*commands.CreateWantsHandler)),
 
-	commands.NewAddToBanListHandler,
-	commands.NewRemoveFromBanListHandler,
-
 	commands.NewHandleIncomingEbtReplicateHandler,
 	wire.Bind(new(portsrpc.EbtReplicateCommandHandler), new(*commands.HandleIncomingEbtReplicateHandler)),
 
-	commands.NewRoomsAliasRegisterHandler,
-	commands.NewRoomsAliasRevokeHandler,
-
 	commands.NewProcessRoomAttendantEventHandler,
 	wire.Bind(new(pubsub.ProcessRoomAttendantEventHandler), new(*commands.ProcessRoomAttendantEventHandler)),
-
-	commands.NewDownloadFeedHandler,
 
 	commands.NewAcceptTunnelConnectHandler,
 	wire.Bind(new(portsrpc.AcceptTunnelConnectHandler), new(*commands.AcceptTunnelConnectHandler)),

--- a/di/inject_ports.go
+++ b/di/inject_ports.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/google/wire"
 	"github.com/planetary-social/scuttlego/logging"
-	"github.com/planetary-social/scuttlego/service/app"
 	"github.com/planetary-social/scuttlego/service/domain/network/local"
 	"github.com/planetary-social/scuttlego/service/domain/transport/rpc/mux"
 	portsnetwork "github.com/planetary-social/scuttlego/service/ports/network"
@@ -40,9 +39,9 @@ var portsSet = wire.NewSet(
 func newListener(
 	ctx context.Context,
 	initializer portsnetwork.ServerPeerInitializer,
-	app app.Application,
+	handler portsnetwork.AcceptNewPeerCommandHandler,
 	config Config,
 	logger logging.Logger,
 ) (*portsnetwork.Listener, error) {
-	return portsnetwork.NewListener(ctx, initializer, app, config.ListenAddress, logger)
+	return portsnetwork.NewListener(ctx, initializer, handler, config.ListenAddress, logger)
 }

--- a/service/app/application.go
+++ b/service/app/application.go
@@ -14,23 +14,19 @@ type Commands struct {
 	RedeemInvite *commands.RedeemInviteHandler
 	Follow       *commands.FollowHandler
 	PublishRaw   *commands.PublishRawHandler
+	DownloadFeed *commands.DownloadFeedHandler
 
-	Connect                  *commands.ConnectHandler
-	DisconnectAll            *commands.DisconnectAllHandler
-	EstablishNewConnections  *commands.EstablishNewConnectionsHandler
-	AcceptNewPeer            *commands.AcceptNewPeerHandler
-	ProcessNewLocalDiscovery *commands.ProcessNewLocalDiscoveryHandler
+	Connect       *commands.ConnectHandler
+	DisconnectAll *commands.DisconnectAllHandler
 
-	CreateWants  *commands.CreateWantsHandler
 	DownloadBlob *commands.DownloadBlobHandler
 	CreateBlob   *commands.CreateBlobHandler
 
 	AddToBanList      *commands.AddToBanListHandler
 	RemoveFromBanList *commands.RemoveFromBanListHandler
 
-	RoomsAliasRegister        *commands.RoomsAliasRegisterHandler
-	RoomsAliasRevoke          *commands.RoomsAliasRevokeHandler
-	ProcessRoomAttendantEvent *commands.ProcessRoomAttendantEventHandler
+	RoomsAliasRegister *commands.RoomsAliasRegisterHandler
+	RoomsAliasRevoke   *commands.RoomsAliasRevokeHandler
 }
 
 type Queries struct {

--- a/service/ports/network/connection_establisher.go
+++ b/service/ports/network/connection_establisher.go
@@ -5,24 +5,27 @@ import (
 	"time"
 
 	"github.com/planetary-social/scuttlego/logging"
-	"github.com/planetary-social/scuttlego/service/app"
 )
+
+type EstablishNewConnectionsCommandHandler interface {
+	Handle() error
+}
 
 // ConnectionEstablisher periodically triggers the EstablishNewConnections
 // application command.
 type ConnectionEstablisher struct {
 	establishConnectionsEvery time.Duration
-	app                       app.Application
+	handler                   EstablishNewConnectionsCommandHandler
 	logger                    logging.Logger
 }
 
 func NewConnectionEstablisher(
-	app app.Application,
+	handler EstablishNewConnectionsCommandHandler,
 	logger logging.Logger,
 ) *ConnectionEstablisher {
 	return &ConnectionEstablisher{
 		establishConnectionsEvery: 15 * time.Second,
-		app:                       app,
+		handler:                   handler,
 		logger:                    logger.New("connection_establisher"),
 	}
 }
@@ -30,7 +33,7 @@ func NewConnectionEstablisher(
 // Run periodically triggers the command until the context is closed.
 func (d ConnectionEstablisher) Run(ctx context.Context) error {
 	for {
-		if err := d.app.Commands.EstablishNewConnections.Handle(); err != nil {
+		if err := d.handler.Handle(); err != nil {
 			d.logger.WithError(err).Debug("failed to establish new connections")
 		}
 


### PR DESCRIPTION
The application struct is supposed to define commands and queries which can be called externally. This is slightly different from normal approach but this is what we decided at some point. Because of this commands which are strictly internal were removed. This should reduce confusion from the bindings perspective.

Added a missing DownloadFeed command to the application struct.