### PR TITLE
Fix don't send stream close messages for async streams

### DIFF
--- a/service/domain/transport/rpc/response_streams.go
+++ b/service/domain/transport/rpc/response_streams.go
@@ -174,11 +174,13 @@ func (s *ResponseStreams) waitAndCloseResponseStream(rs *responseStream) {
 	s.streamsLock.Lock()
 	defer s.streamsLock.Unlock()
 
-	go func() {
-		if err := sendCloseStream(s.raw, rs.number, nil); err != nil {
-			s.logger.WithError(err).Debug("failed to close the stream")
-		}
-	}()
+	if rs.typ != ProcedureTypeAsync {
+		go func() {
+			if err := sendCloseStream(s.raw, rs.number, nil); err != nil {
+				s.logger.WithError(err).Debug("failed to close the stream")
+			}
+		}()
+	}
 
 	delete(s.streams, rs.number)
 	close(rs.ch)


### PR DESCRIPTION
Apparently sending a close stream message after an error is received from a remote for async procedure calls is considered an error. If that happens peers terminate the connection. So I think the implication is that you are not allowed to terminate the async streams early either since that would require sending an error to the remote.