### PR TITLE
Accelerate replication

### DIFF
--- a/service/domain/feeds/content/transport/marshaler.go
+++ b/service/domain/feeds/content/transport/marshaler.go
@@ -65,7 +65,7 @@ func (m *Marshaler) Unmarshal(b message.RawMessageContent) (content.KnownMessage
 	cnt, err := mapping.Unmarshal(b.Bytes())
 	if err != nil {
 		logger.WithField("typ", typ).WithError(err).Error("mapping returned an error")
-		return nil, errors.Wrapf(err, "mapping '%s' returned an error", typ)
+		return content.NewUnknown(b.Bytes())
 	}
 
 	return cnt, nil


### PR DESCRIPTION
Since the transactions are batched it was previously possible that messages will be dropped from the buffer when the transaction was repeated - the transactions weren't idempotent. This has been fixed.

Additionally previously encountering a malformed known message meant that an error is returned. This has now been changed and malformed messages are persisted without errors. They will have to be rescanned using migrations if the code parsing messages is at fault when the error occurs.