### PR TITLE
Ignore errors when appending messages to feeds during data migration

### DIFF
--- a/service/adapters/migrations/command_import_data_from_go_ssb_handler_adapter.go
+++ b/service/adapters/migrations/command_import_data_from_go_ssb_handler_adapter.go
@@ -46,7 +46,7 @@ func (a *CommandImportDataFromGoSSBHandlerAdapter) Fn(ctx context.Context, state
 		return errors.Wrap(err, "could not create a command")
 	}
 
-	err = a.m.MigrationImportDataFromGoSSB.Handle(ctx, cmd)
+	_, err = a.m.MigrationImportDataFromGoSSB.Handle(ctx, cmd)
 	if err != nil {
 		return errors.Wrap(err, "could not run a command")
 	}

--- a/service/adapters/mocks/feed_repository.go
+++ b/service/adapters/mocks/feed_repository.go
@@ -46,6 +46,13 @@ func (m *FeedRepositoryMock) UpdateFeed(ref refs.Feed, f commands.UpdateFeedFn) 
 }
 
 func (m *FeedRepositoryMock) UpdateFeedIgnoringReceiveLog(ref refs.Feed, f commands.UpdateFeedFn) error {
+	call := FeedRepositoryMockUpdateFeedIgnoringReceiveLogCall{
+		Feed: ref,
+	}
+	defer func() {
+		m.updateFeedIgnoringReceiveLogCalls = append(m.updateFeedIgnoringReceiveLogCalls, call)
+	}()
+
 	feed := feeds.NewFeed(nil)
 	if err := f(feed); err != nil {
 		return errors.Wrap(err, "error")
@@ -55,10 +62,7 @@ func (m *FeedRepositoryMock) UpdateFeedIgnoringReceiveLog(ref refs.Feed, f comma
 	for _, msg := range messagesToPersist {
 		messageRefs = append(messageRefs, msg.Message().Id())
 	}
-	m.updateFeedIgnoringReceiveLogCalls = append(m.updateFeedIgnoringReceiveLogCalls, FeedRepositoryMockUpdateFeedIgnoringReceiveLogCall{
-		Feed:              ref,
-		MessagesToPersist: messageRefs,
-	})
+	call.MessagesToPersist = messageRefs
 	return nil
 }
 


### PR DESCRIPTION
Our task is to import as many messages as possible. We know that there is invalid data in go-ssb receive logs. Therefore it makes sense to try to ignore any errors and just try to import as many messages as possible because otherwise someone is just going to be stuck importing their data.