### PR TITLE
Store blobs like go-ssb stores them

### DIFF
--- a/di/inject_adapters.go
+++ b/di/inject_adapters.go
@@ -100,7 +100,7 @@ var blobsAdaptersSet = wire.NewSet(
 )
 
 func newFilesystemStorage(logger logging.Logger, config Config) (*blobs.FilesystemStorage, error) {
-	return blobs.NewFilesystemStorage(path.Join(config.DataDirectory, "blobs"), logger)
+	return blobs.NewFilesystemStorage(path.Join(config.GoSSBDataDirectory, "blobs"), logger)
 }
 
 //nolint:unused


### PR DESCRIPTION
Planetary's existing users already have a lot of data stored on their devices. This data is comprised of messages and blobs. We intend to migrate the messages right away but initially we want to avoid touching the blobs. The reason for this is as follows:
- we could copy the blobs but then we may risk using a lot of storage space which is limited on phones
- we could try to move the blobs but then we alter go-ssb's data which makes going back to using go-ssb in case of some kind of a critical bug in scuttlego more difficult

For this reason initially we want to store the blobs in the exact same way as go-ssb stores them. We will migrate them later which will probably involve moving the entire directory containing the blobs to a new location.