### PR TITLE
Add PublishRawAsIdentity command

### DIFF
--- a/di/inject_application.go
+++ b/di/inject_application.go
@@ -28,6 +28,7 @@ var commandsSet = wire.NewSet(
 	commands.NewConnectHandler,
 	commands.NewDisconnectAllHandler,
 	commands.NewPublishRawHandler,
+	commands.NewPublishRawAsIdentityHandler,
 	commands.NewDownloadBlobHandler,
 	commands.NewCreateBlobHandler,
 	commands.NewDownloadFeedHandler,

--- a/di/wire.go
+++ b/di/wire.go
@@ -287,6 +287,9 @@ func BuildService(context.Context, identity.Private, Config) (Service, error) {
 		invites.NewInviteRedeemer,
 		wire.Bind(new(commands.InviteRedeemer), new(*invites.InviteRedeemer)),
 
+		commands.NewTransactionRawMessagePublisher,
+		wire.Bind(new(commands.RawMessagePublisher), new(*commands.TransactionRawMessagePublisher)),
+
 		portsSet,
 		applicationSet,
 		replicatorSet,

--- a/di/wire_gen.go
+++ b/di/wire_gen.go
@@ -345,7 +345,9 @@ func BuildService(contextContext context.Context, private identity.Private, conf
 		return Service{}, err
 	}
 	followHandler := commands.NewFollowHandler(transactionProvider, private, marshaler, logger)
-	publishRawHandler := commands.NewPublishRawHandler(transactionProvider, private, logger)
+	transactionRawMessagePublisher := commands.NewTransactionRawMessagePublisher(transactionProvider)
+	publishRawHandler := commands.NewPublishRawHandler(transactionRawMessagePublisher, private)
+	publishRawAsIdentityHandler := commands.NewPublishRawAsIdentityHandler(transactionRawMessagePublisher)
 	downloadFeedHandler := commands.NewDownloadFeedHandler(transactionProvider, currentTimeProvider)
 	peerManagerConfig := extractPeerManagerConfigFromConfig(config)
 	tunnelDialer := tunnel.NewDialer(peerInitializer)
@@ -408,19 +410,20 @@ func BuildService(contextContext context.Context, private identity.Private, conf
 	}
 	runMigrationsHandler := commands.NewRunMigrationsHandler(runner, migrationsMigrations)
 	appCommands := app.Commands{
-		RedeemInvite:       redeemInviteHandler,
-		Follow:             followHandler,
-		PublishRaw:         publishRawHandler,
-		DownloadFeed:       downloadFeedHandler,
-		Connect:            connectHandler,
-		DisconnectAll:      disconnectAllHandler,
-		DownloadBlob:       downloadBlobHandler,
-		CreateBlob:         createBlobHandler,
-		AddToBanList:       addToBanListHandler,
-		RemoveFromBanList:  removeFromBanListHandler,
-		RoomsAliasRegister: roomsAliasRegisterHandler,
-		RoomsAliasRevoke:   roomsAliasRevokeHandler,
-		RunMigrations:      runMigrationsHandler,
+		RedeemInvite:         redeemInviteHandler,
+		Follow:               followHandler,
+		PublishRaw:           publishRawHandler,
+		PublishRawAsIdentity: publishRawAsIdentityHandler,
+		DownloadFeed:         downloadFeedHandler,
+		Connect:              connectHandler,
+		DisconnectAll:        disconnectAllHandler,
+		DownloadBlob:         downloadBlobHandler,
+		CreateBlob:           createBlobHandler,
+		AddToBanList:         addToBanListHandler,
+		RemoveFromBanList:    removeFromBanListHandler,
+		RoomsAliasRegister:   roomsAliasRegisterHandler,
+		RoomsAliasRevoke:     roomsAliasRevokeHandler,
+		RunMigrations:        runMigrationsHandler,
 	}
 	readReceiveLogRepository := bolt.NewReadReceiveLogRepository(db, txRepositoriesFactory)
 	receiveLogHandler := queries.NewReceiveLogHandler(readReceiveLogRepository)

--- a/service/adapters/mocks/feed_repository.go
+++ b/service/adapters/mocks/feed_repository.go
@@ -21,6 +21,10 @@ type FeedRepositoryMockGetMessageCall struct {
 	Seq  message.Sequence
 }
 
+type FeedRepositoryMockUpdateFeedCall struct {
+	Feed refs.Feed
+}
+
 type FeedRepositoryMockUpdateFeedIgnoringReceiveLogCall struct {
 	Feed              refs.Feed
 	MessagesToPersist []refs.Message
@@ -34,6 +38,7 @@ type FeedRepositoryMock struct {
 	getMessageCalls       []FeedRepositoryMockGetMessageCall
 	GetMessageReturnValue message.Message
 
+	updateFeedCalls                   []FeedRepositoryMockUpdateFeedCall
 	updateFeedIgnoringReceiveLogCalls []FeedRepositoryMockUpdateFeedIgnoringReceiveLogCall
 
 	CountReturnValue int
@@ -41,8 +46,16 @@ type FeedRepositoryMock struct {
 	lock sync.Mutex
 }
 
+func NewFeedRepositoryMock() *FeedRepositoryMock {
+	return &FeedRepositoryMock{}
+}
+
 func (m *FeedRepositoryMock) UpdateFeed(ref refs.Feed, f commands.UpdateFeedFn) error {
-	return errors.New("not implemented")
+	call := FeedRepositoryMockUpdateFeedCall{
+		Feed: ref,
+	}
+	m.updateFeedCalls = append(m.updateFeedCalls, call)
+	return nil
 }
 
 func (m *FeedRepositoryMock) UpdateFeedIgnoringReceiveLog(ref refs.Feed, f commands.UpdateFeedFn) error {
@@ -68,10 +81,6 @@ func (m *FeedRepositoryMock) UpdateFeedIgnoringReceiveLog(ref refs.Feed, f comma
 
 func (m *FeedRepositoryMock) DeleteFeed(ref refs.Feed) error {
 	return errors.New("not implemented")
-}
-
-func NewFeedRepositoryMock() *FeedRepositoryMock {
-	return &FeedRepositoryMock{}
 }
 
 func (m *FeedRepositoryMock) GetMessages(id refs.Feed, seq *message.Sequence, limit *int) ([]message.Message, error) {
@@ -118,5 +127,14 @@ func (m *FeedRepositoryMock) UpdateFeedIgnoringReceiveLogCalls() []FeedRepositor
 
 	tmp := make([]FeedRepositoryMockUpdateFeedIgnoringReceiveLogCall, len(m.updateFeedIgnoringReceiveLogCalls))
 	copy(tmp, m.updateFeedIgnoringReceiveLogCalls)
+	return tmp
+}
+
+func (m *FeedRepositoryMock) UpdateFeedCalls() []FeedRepositoryMockUpdateFeedCall {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	tmp := make([]FeedRepositoryMockUpdateFeedCall, len(m.updateFeedCalls))
+	copy(tmp, m.updateFeedCalls)
 	return tmp
 }

--- a/service/app/application.go
+++ b/service/app/application.go
@@ -11,10 +11,11 @@ type Application struct {
 }
 
 type Commands struct {
-	RedeemInvite *commands.RedeemInviteHandler
-	Follow       *commands.FollowHandler
-	PublishRaw   *commands.PublishRawHandler
-	DownloadFeed *commands.DownloadFeedHandler
+	RedeemInvite         *commands.RedeemInviteHandler
+	Follow               *commands.FollowHandler
+	PublishRaw           *commands.PublishRawHandler
+	PublishRawAsIdentity *commands.PublishRawAsIdentityHandler
+	DownloadFeed         *commands.DownloadFeedHandler
 
 	Connect       *commands.ConnectHandler
 	DisconnectAll *commands.DisconnectAllHandler

--- a/service/app/commands/handler_publish_raw_as_identity.go
+++ b/service/app/commands/handler_publish_raw_as_identity.go
@@ -1,0 +1,63 @@
+package commands
+
+import (
+	"github.com/boreq/errors"
+	"github.com/planetary-social/scuttlego/service/domain/feeds/message"
+	"github.com/planetary-social/scuttlego/service/domain/identity"
+	"github.com/planetary-social/scuttlego/service/domain/refs"
+)
+
+type RawMessagePublisher interface {
+	Publish(identity identity.Private, content message.RawMessageContent) (refs.Message, error)
+}
+
+type PublishRawAsIdentity struct {
+	content  []byte
+	identity identity.Private
+}
+
+func NewPublishRawAsIdentity(content []byte, identity identity.Private) (PublishRawAsIdentity, error) {
+	if len(content) == 0 {
+		return PublishRawAsIdentity{}, errors.New("zero length of content")
+	}
+
+	if identity.IsZero() {
+		return PublishRawAsIdentity{}, errors.New("zero value of identity")
+	}
+
+	return PublishRawAsIdentity{content: content, identity: identity}, nil
+}
+
+func (cmd PublishRawAsIdentity) IsZero() bool {
+	return cmd.identity.IsZero()
+}
+
+type PublishRawAsIdentityHandler struct {
+	publisher RawMessagePublisher
+}
+
+func NewPublishRawAsIdentityHandler(
+	publisher RawMessagePublisher,
+) *PublishRawAsIdentityHandler {
+	return &PublishRawAsIdentityHandler{
+		publisher: publisher,
+	}
+}
+
+func (h *PublishRawAsIdentityHandler) Handle(cmd PublishRawAsIdentity) (refs.Message, error) {
+	if cmd.IsZero() {
+		return refs.Message{}, errors.New("zero value of cmd")
+	}
+
+	content, err := message.NewRawMessageContent(cmd.content)
+	if err != nil {
+		return refs.Message{}, errors.Wrap(err, "could not create raw message content")
+	}
+
+	ref, err := h.publisher.Publish(cmd.identity, content)
+	if err != nil {
+		return refs.Message{}, errors.Wrap(err, "publishing error")
+	}
+
+	return ref, nil
+}

--- a/service/app/commands/raw_message_publisher.go
+++ b/service/app/commands/raw_message_publisher.go
@@ -1,0 +1,51 @@
+package commands
+
+import (
+	"time"
+
+	"github.com/boreq/errors"
+	"github.com/planetary-social/scuttlego/service/domain/feeds"
+	"github.com/planetary-social/scuttlego/service/domain/feeds/message"
+	"github.com/planetary-social/scuttlego/service/domain/identity"
+	"github.com/planetary-social/scuttlego/service/domain/refs"
+)
+
+type TransactionRawMessagePublisher struct {
+	transaction TransactionProvider
+}
+
+func NewTransactionRawMessagePublisher(transaction TransactionProvider) *TransactionRawMessagePublisher {
+	return &TransactionRawMessagePublisher{transaction: transaction}
+}
+
+func (h *TransactionRawMessagePublisher) Publish(identity identity.Private, content message.RawMessageContent) (refs.Message, error) {
+	if identity.IsZero() {
+		return refs.Message{}, errors.New("zero value of identity")
+	}
+
+	if content.IsZero() {
+		return refs.Message{}, errors.New("zero value of content")
+	}
+
+	identityRef, err := refs.NewIdentityFromPublic(identity.Public())
+	if err != nil {
+		return refs.Message{}, errors.Wrap(err, "could not create the identity ref")
+	}
+
+	var id refs.Message
+
+	if err := h.transaction.Transact(func(adapters Adapters) error {
+		return adapters.Feed.UpdateFeed(identityRef.MainFeed(), func(feed *feeds.Feed) error {
+			var err error
+			id, err = feed.CreateMessage(content, time.Now(), identity)
+			if err != nil {
+				return errors.Wrap(err, "failed to create a message")
+			}
+			return nil
+		})
+	}); err != nil {
+		return refs.Message{}, errors.Wrap(err, "transaction failed")
+	}
+
+	return id, nil
+}

--- a/service/app/commands/raw_message_publisher_test.go
+++ b/service/app/commands/raw_message_publisher_test.go
@@ -1,0 +1,40 @@
+package commands_test
+
+import (
+	"testing"
+
+	"github.com/planetary-social/scuttlego/fixtures"
+	"github.com/planetary-social/scuttlego/service/adapters/mocks"
+	"github.com/planetary-social/scuttlego/service/app/commands"
+	"github.com/planetary-social/scuttlego/service/domain/feeds/message"
+	"github.com/planetary-social/scuttlego/service/domain/refs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRawMessagePublisher(t *testing.T) {
+	feedRepository := mocks.NewFeedRepositoryMock()
+
+	adapters := commands.Adapters{
+		Feed: feedRepository,
+	}
+
+	transactionProvider := mocks.NewMockTransactionProvider(adapters)
+
+	iden := fixtures.SomePrivateIdentity()
+	content := message.MustNewRawMessageContent(fixtures.SomeBytes())
+
+	publisher := commands.NewTransactionRawMessagePublisher(transactionProvider)
+	_, err := publisher.Publish(iden, content)
+	require.NoError(t, err)
+
+	ref := refs.MustNewIdentityFromPublic(iden.Public())
+
+	require.Equal(t,
+		[]mocks.FeedRepositoryMockUpdateFeedCall{
+			{
+				Feed: ref.MainFeed(),
+			},
+		},
+		feedRepository.UpdateFeedCalls(),
+	)
+}


### PR DESCRIPTION
This command can be used to publish messages using the specified identity to its main feed. This is needed for testing the bindings as Swift requires a function like this.