### PR TITLE
Close the listener when context expires

### DIFF
--- a/service/ports/network/listener.go
+++ b/service/ports/network/listener.go
@@ -63,6 +63,13 @@ func (l *Listener) ListenAndServe(ctx context.Context) error {
 		return errors.Wrap(err, "could not start a listener")
 	}
 
+	go func() {
+		<-ctx.Done()
+		if err := listener.Close(); err != nil {
+			l.logger.WithError(err).Error("error closing the listener")
+		}
+	}()
+
 	for {
 		conn, err := listener.Accept()
 		if err != nil {


### PR DESCRIPTION
This is not documented but closing the context passed to Listen doesn't close the listener.

See https://github.com/golang/go/issues/28120.