### PR TITLE
Don't try to scope Github Action caches using go.sum

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,9 @@ jobs:
           path: |
             ${{ steps.golang-path.outputs.build }}
             ${{ steps.golang-path.outputs.module }}
-          key: ${{ runner.os }}-golang-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-golang
           restore-keys: |
-            ${{ runner.os }}-golang-
+            ${{ runner.os }}-golang
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2


### PR DESCRIPTION
The cache is reusable and useful across go.sum files as far as I know and our config was wrongly ordered anyway so this option had no effect.