### PR TITLE
Include Makefile in cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
           path: |
             ${{ steps.golang-path.outputs.build }}
             ${{ steps.golang-path.outputs.module }}
-          key: ${{ runner.os }}-golang-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-golang-${{ hashFiles('**/go.sum', 'Makefile') }}
           restore-keys: |
             ${{ runner.os }}-golang-
 

--- a/Makefile
+++ b/Makefile
@@ -29,4 +29,4 @@ lint:
 .PHONY: tools
 tools:
 	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.1
-	go install github.com/rinchsan/gosimports/cmd/gosimports@latest # https://github.com/golang/go/issues/20818
+	go install github.com/rinchsan/gosimports/cmd/gosimports@v0.3.5 # https://github.com/golang/go/issues/20818


### PR DESCRIPTION
I think since Makefile contains some tool versions it also needs to be included in cache. I also hardcoded the other tool version to keep things consistent.