### PR TITLE
Call progress callback when migrations are executed

### DIFF
--- a/migrations/migrations_test.go
+++ b/migrations/migrations_test.go
@@ -2,6 +2,7 @@ package migrations_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/planetary-social/scuttlego/fixtures"
@@ -15,8 +16,9 @@ func TestRunner_MigrationsCanBeEmpty(t *testing.T) {
 
 	ctx := fixtures.TestContext(t)
 	m := migrations.MustNewMigrations(nil)
+	callback := newProgressCallbackMock()
 
-	err := r.Runner.Run(ctx, m)
+	err := r.Runner.Run(ctx, m, callback)
 	require.NoError(t, err)
 
 	require.Empty(t, r.Storage.saveStateCalls)
@@ -42,8 +44,9 @@ func TestRunner_MigrationIsExecutedWithEmptyInitializedStateIfNoStateIsSaved(t *
 			},
 		),
 	})
+	callback := newProgressCallbackMock()
 
-	err := r.Runner.Run(ctx, m)
+	err := r.Runner.Run(ctx, m, callback)
 	require.NoError(t, err)
 
 	require.Equal(t,
@@ -79,9 +82,10 @@ func TestRunner_MigrationIsExecutedWithSavedStateIfStateWasSaved(t *testing.T) {
 		fixtures.SomeString(): fixtures.SomeString(),
 	}
 
-	r.Storage.returnedState = internal.Ptr(someState)
+	r.Storage.MockState(name, someState)
+	callback := newProgressCallbackMock()
 
-	err := r.Runner.Run(ctx, m)
+	err := r.Runner.Run(ctx, m, callback)
 	require.NoError(t, err)
 
 	require.Equal(t,
@@ -109,8 +113,9 @@ func TestRunner_MigrationIsExecutedIfNoStatusIsSaved(t *testing.T) {
 			},
 		),
 	})
+	callback := newProgressCallbackMock()
 
-	err := r.Runner.Run(ctx, m)
+	err := r.Runner.Run(ctx, m, callback)
 	require.NoError(t, err)
 
 	require.Equal(t,
@@ -162,8 +167,9 @@ func TestRunner_StatusIsSavedBasedOnReturnedErrors(t *testing.T) {
 				},
 			),
 		})
+		callback := newProgressCallbackMock()
 
-		err := r.Runner.Run(ctx, m)
+		err := r.Runner.Run(ctx, m, callback)
 		if testCase.ReturnedError == nil {
 			require.NoError(t, err)
 		} else {
@@ -197,9 +203,10 @@ func TestRunner_MigrationIsNotExecutedIfItPreviouslySucceeded(t *testing.T) {
 		),
 	})
 
-	r.Storage.returnedStatus = internal.Ptr(migrations.StatusFinished)
+	r.Storage.MockStatus(name, migrations.StatusFinished)
+	callback := newProgressCallbackMock()
 
-	err := r.Runner.Run(ctx, m)
+	err := r.Runner.Run(ctx, m, callback)
 	require.NoError(t, err)
 
 	require.Empty(t, r.Storage.loadStateCalls)
@@ -228,9 +235,10 @@ func TestRunner_MigrationIsExecutedIfItPreviouslyFailed(t *testing.T) {
 		),
 	})
 
-	r.Storage.returnedStatus = internal.Ptr(migrations.StatusFailed)
+	r.Storage.MockStatus(name, migrations.StatusFailed)
+	callback := newProgressCallbackMock()
 
-	err := r.Runner.Run(ctx, m)
+	err := r.Runner.Run(ctx, m, callback)
 	require.NoError(t, err)
 
 	require.Equal(t,
@@ -272,8 +280,9 @@ func TestRunner_MigrationsAreConsideredInOrder(t *testing.T) {
 			},
 		),
 	})
+	callback := newProgressCallbackMock()
 
-	err := r.Runner.Run(ctx, m)
+	err := r.Runner.Run(ctx, m, callback)
 	require.NoError(t, err)
 
 	require.Equal(t,
@@ -317,7 +326,8 @@ func TestRunner_MigrationsCanSaveState(t *testing.T) {
 	})
 
 	ctx := fixtures.TestContext(t)
-	err := r.Runner.Run(ctx, m)
+	callback := newProgressCallbackMock()
+	err := r.Runner.Run(ctx, m, callback)
 	require.NoError(t, err)
 
 	require.Equal(t,
@@ -329,6 +339,223 @@ func TestRunner_MigrationsCanSaveState(t *testing.T) {
 		},
 		r.Storage.saveStateCalls,
 	)
+}
+
+func TestRunner_IfMigrationsAreEmptyOnlyOnDoneProgressCallbackIsCalled(t *testing.T) {
+	r := newTestRunner(t)
+
+	ctx := fixtures.TestContext(t)
+	m := migrations.MustNewMigrations(nil)
+	callback := newProgressCallbackMock()
+
+	err := r.Runner.Run(ctx, m, callback)
+	require.NoError(t, err)
+
+	require.Empty(t, callback.OnRunningCalls)
+	require.Empty(t, callback.OnErrorCalls)
+	require.Equal(t,
+		[]progressCallbackMockOnDoneCall{
+			{
+				MigrationsCount: 0,
+			},
+		},
+		callback.OnDoneCalls,
+	)
+}
+
+func TestRunner_OnRunningProgressCallbackIsCalledWhenMigrationsAreRun(t *testing.T) {
+	r := newTestRunner(t)
+
+	ctx := fixtures.TestContext(t)
+
+	noop := func(ctx context.Context, state migrations.State, saveStateFunc migrations.SaveStateFunc) error {
+		return nil
+	}
+
+	m := migrations.MustNewMigrations([]migrations.Migration{
+		migrations.MustNewMigration(fixtures.SomeString(), noop),
+		migrations.MustNewMigration(fixtures.SomeString(), noop),
+	})
+
+	callback := newProgressCallbackMock()
+
+	err := r.Runner.Run(ctx, m, callback)
+	require.NoError(t, err)
+
+	require.Equal(t,
+		[]progressCallbackMockOnRunningCall{
+			{
+				MigrationIndex:  0,
+				MigrationsCount: 2,
+			},
+			{
+				MigrationIndex:  1,
+				MigrationsCount: 2,
+			},
+		},
+		callback.OnRunningCalls,
+	)
+	require.Empty(t, callback.OnErrorCalls)
+	require.Equal(t,
+		[]progressCallbackMockOnDoneCall{
+			{
+				MigrationsCount: 2,
+			},
+		},
+		callback.OnDoneCalls,
+	)
+}
+
+func TestRunner_OnRunningProgressCallbackIsOnlyCalledIfMigrationNeedsToBeRun(t *testing.T) {
+	r := newTestRunner(t)
+
+	ctx := fixtures.TestContext(t)
+
+	name1 := fixtures.SomeString()
+	name2 := fixtures.SomeString()
+	name3 := fixtures.SomeString()
+
+	noop := func(ctx context.Context, state migrations.State, saveStateFunc migrations.SaveStateFunc) error {
+		return nil
+	}
+
+	m := migrations.MustNewMigrations([]migrations.Migration{
+		migrations.MustNewMigration(name1, noop),
+		migrations.MustNewMigration(name2, noop),
+		migrations.MustNewMigration(name3, noop),
+	})
+
+	r.Storage.MockStatus(name1, migrations.StatusFinished)
+
+	callback := newProgressCallbackMock()
+
+	err := r.Runner.Run(ctx, m, callback)
+	require.NoError(t, err)
+
+	require.Equal(t,
+		[]progressCallbackMockOnRunningCall{
+			{
+				MigrationIndex:  1,
+				MigrationsCount: 3,
+			},
+			{
+				MigrationIndex:  2,
+				MigrationsCount: 3,
+			},
+		},
+		callback.OnRunningCalls,
+	)
+	require.Empty(t, callback.OnErrorCalls)
+	require.Equal(t,
+		[]progressCallbackMockOnDoneCall{
+			{
+				MigrationsCount: 3,
+			},
+		},
+		callback.OnDoneCalls,
+	)
+}
+
+func TestRunner_BothOnProgressAndOnErrorProgressCallbacksAreCalledIfMigrationFails(t *testing.T) {
+	r := newTestRunner(t)
+
+	ctx := fixtures.TestContext(t)
+
+	name1 := fixtures.SomeString()
+	name2 := fixtures.SomeString()
+	someError := fixtures.SomeError()
+
+	noop := func(ctx context.Context, state migrations.State, saveStateFunc migrations.SaveStateFunc) error {
+		return nil
+	}
+
+	returnsError := func(ctx context.Context, state migrations.State, saveStateFunc migrations.SaveStateFunc) error {
+		return someError
+	}
+
+	m := migrations.MustNewMigrations([]migrations.Migration{
+		migrations.MustNewMigration(name1, noop),
+		migrations.MustNewMigration(name2, returnsError),
+	})
+
+	callback := newProgressCallbackMock()
+
+	err := r.Runner.Run(ctx, m, callback)
+	require.Error(t, err)
+
+	require.Equal(t,
+		[]progressCallbackMockOnRunningCall{
+			{
+				MigrationIndex:  0,
+				MigrationsCount: 2,
+			},
+			{
+				MigrationIndex:  1,
+				MigrationsCount: 2,
+			},
+		},
+		callback.OnRunningCalls,
+	)
+	require.Len(t, callback.OnErrorCalls, 1)
+	require.Equal(t, 1, callback.OnErrorCalls[0].MigrationIndex)
+	require.Equal(t, 2, callback.OnErrorCalls[0].MigrationsCount)
+	require.EqualError(t,
+		callback.OnErrorCalls[0].Err,
+		fmt.Sprintf(
+			"error running migration '%s': 1 error occurred:\n\t* migration function returned an error: %s\n\n",
+			name2,
+			someError.Error(),
+		),
+	)
+	require.Empty(t, callback.OnDoneCalls)
+}
+
+func TestRunner_OnlyOnErrorProgressCallbackIsCalledIfStatusLoadingFails(t *testing.T) {
+	r := newTestRunner(t)
+
+	ctx := fixtures.TestContext(t)
+
+	name1 := fixtures.SomeString()
+	name2 := fixtures.SomeString()
+	someError := fixtures.SomeError()
+
+	noop := func(ctx context.Context, state migrations.State, saveStateFunc migrations.SaveStateFunc) error {
+		return nil
+	}
+
+	m := migrations.MustNewMigrations([]migrations.Migration{
+		migrations.MustNewMigration(name1, noop),
+		migrations.MustNewMigration(name2, noop),
+	})
+
+	callback := newProgressCallbackMock()
+
+	r.Storage.MockLoadStatusError(name2, someError)
+
+	err := r.Runner.Run(ctx, m, callback)
+	require.Error(t, err)
+
+	require.Equal(t,
+		[]progressCallbackMockOnRunningCall{
+			{
+				MigrationIndex:  0,
+				MigrationsCount: 2,
+			},
+		},
+		callback.OnRunningCalls,
+	)
+	require.Len(t, callback.OnErrorCalls, 1)
+	require.Equal(t, 1, callback.OnErrorCalls[0].MigrationIndex)
+	require.Equal(t, 2, callback.OnErrorCalls[0].MigrationsCount)
+	require.EqualError(t,
+		callback.OnErrorCalls[0].Err,
+		fmt.Sprintf(
+			"error running migration '%s': error checking if migration should be run: error loading status: %s",
+			name2,
+			someError.Error(),
+		),
+	)
+	require.Empty(t, callback.OnDoneCalls)
 }
 
 type testRunner struct {
@@ -353,20 +580,38 @@ type storageMock struct {
 	saveStateCalls  []saveStateCall
 	saveStatusCalls []saveStatusCall
 
-	returnedState  *migrations.State
-	returnedStatus *migrations.Status
+	returnedState    map[string]migrations.State
+	returnedStatus   map[string]migrations.Status
+	loadStatusErrors map[string]error
 }
 
 func newStorageMock() *storageMock {
-	return &storageMock{}
+	return &storageMock{
+		returnedStatus:   make(map[string]migrations.Status),
+		returnedState:    make(map[string]migrations.State),
+		loadStatusErrors: make(map[string]error),
+	}
+}
+
+func (s *storageMock) MockState(name string, state migrations.State) {
+	s.returnedState[name] = state
+}
+
+func (s *storageMock) MockStatus(name string, status migrations.Status) {
+	s.returnedStatus[name] = status
+}
+
+func (s *storageMock) MockLoadStatusError(name string, err error) {
+	s.loadStatusErrors[name] = err
 }
 
 func (s *storageMock) LoadState(name string) (migrations.State, error) {
 	s.loadStateCalls = append(s.loadStateCalls, loadStateCall{name: name})
-	if s.returnedState == nil {
+	state, ok := s.returnedState[name]
+	if !ok {
 		return nil, migrations.ErrStateNotFound
 	}
-	return *s.returnedState, nil
+	return state, nil
 }
 
 func (s *storageMock) SaveState(name string, state migrations.State) error {
@@ -376,10 +621,16 @@ func (s *storageMock) SaveState(name string, state migrations.State) error {
 
 func (s *storageMock) LoadStatus(name string) (migrations.Status, error) {
 	s.loadStatusCalls = append(s.loadStatusCalls, loadStatusCall{name: name})
-	if s.returnedStatus == nil {
+
+	if err := s.loadStatusErrors[name]; err != nil {
+		return migrations.Status{}, err
+	}
+
+	status, ok := s.returnedStatus[name]
+	if !ok {
 		return migrations.Status{}, migrations.ErrStatusNotFound
 	}
-	return *s.returnedStatus, nil
+	return status, nil
 }
 
 func (s *storageMock) SaveStatus(name string, status migrations.Status) error {
@@ -434,4 +685,50 @@ func TestNewMigrations_ZeroValuesOfMigrationsAreNotAllowed(t *testing.T) {
 		},
 	)
 	require.EqualError(t, err, "zero value of migration")
+}
+
+type progressCallbackMockOnRunningCall struct {
+	MigrationIndex  int
+	MigrationsCount int
+}
+
+type progressCallbackMockOnErrorCall struct {
+	MigrationIndex  int
+	MigrationsCount int
+	Err             error
+}
+
+type progressCallbackMockOnDoneCall struct {
+	MigrationsCount int
+}
+
+type progressCallbackMock struct {
+	OnRunningCalls []progressCallbackMockOnRunningCall
+	OnErrorCalls   []progressCallbackMockOnErrorCall
+	OnDoneCalls    []progressCallbackMockOnDoneCall
+}
+
+func newProgressCallbackMock() *progressCallbackMock {
+	return &progressCallbackMock{}
+}
+
+func (p *progressCallbackMock) OnRunning(migrationIndex int, migrationsCount int) {
+	p.OnRunningCalls = append(p.OnRunningCalls, progressCallbackMockOnRunningCall{
+		MigrationIndex:  migrationIndex,
+		MigrationsCount: migrationsCount,
+	})
+}
+
+func (p *progressCallbackMock) OnError(migrationIndex int, migrationsCount int, err error) {
+	p.OnErrorCalls = append(p.OnErrorCalls, progressCallbackMockOnErrorCall{
+		MigrationIndex:  migrationIndex,
+		MigrationsCount: migrationsCount,
+		Err:             err,
+	})
+}
+
+func (p *progressCallbackMock) OnDone(migrationsCount int) {
+	p.OnDoneCalls = append(p.OnDoneCalls, progressCallbackMockOnDoneCall{
+		MigrationsCount: migrationsCount,
+	})
 }

--- a/service/app/commands/handler_run_migrations.go
+++ b/service/app/commands/handler_run_migrations.go
@@ -3,11 +3,27 @@ package commands
 import (
 	"context"
 
+	"github.com/boreq/errors"
 	"github.com/planetary-social/scuttlego/migrations"
 )
 
 type MigrationsRunner interface {
-	Run(ctx context.Context, migrations migrations.Migrations) error
+	Run(ctx context.Context, migrations migrations.Migrations, progressCallback migrations.ProgressCallback) error
+}
+
+type RunMigrations struct {
+	progressCallback migrations.ProgressCallback
+}
+
+func NewRunMigrations(progressCallback migrations.ProgressCallback) (RunMigrations, error) {
+	if progressCallback == nil {
+		return RunMigrations{}, errors.New("nil progress callback")
+	}
+	return RunMigrations{progressCallback: progressCallback}, nil
+}
+
+func (cmd RunMigrations) IsZero() bool {
+	return cmd == RunMigrations{}
 }
 
 type RunMigrationsHandler struct {
@@ -25,6 +41,10 @@ func NewRunMigrationsHandler(
 	}
 }
 
-func (h RunMigrationsHandler) Run(ctx context.Context) error {
-	return h.runner.Run(ctx, h.migrations)
+func (h RunMigrationsHandler) Run(ctx context.Context, cmd RunMigrations) error {
+	if cmd.IsZero() {
+		return errors.New("zero value of cmd")
+	}
+
+	return h.runner.Run(ctx, h.migrations, cmd.progressCallback)
 }


### PR DESCRIPTION
- OnRunning is only called when a particular migration has to be
  executed so if all migrations were already executed this will not be
  called, if status loading fails for a migration this callback will not
  be triggered
- OnError is only called when a particular migration fails, if this
  callback is triggered it is only triggered once and is the last
  callback to be triggered
- OnDone is only called once there are no more migrations remaining to
  be executed (including if there are no migrations to consider) and
  there were no errors so if this callback is triggered it is triggered
  only once and is the last callback to be triggered

Example valid call sequences:

- no migrations:
  - OnDone(count=0)

- we had three migrations, they all had to be run and executed correctly:
  - OnRunning(index=0, count=3)
  - OnRunning(index=1, count=3)
  - OnRunning(index=2, count=3)
  - OnDone(count=3)

- we had three migrations, not all had to be run and they executed correctly:
  - OnRunning(index=2, count=3)
  - OnDone(count=3)

- we had three migrations, they all had to be run and the second one failed:
  - OnRunning(index=0, count=3)
  - OnRunning(index=1, count=3)
  - OnError(index=1, count=3)

- we had three migrations, one migration executed correctly and status
  loading failed for the second one:
  - OnRunning(index=0, count=3)
  - OnError(index=1, count=3)