### PR TITLE
Make sure that we are not illegaly reusing badger keys

### DIFF
--- a/cmd/log-debugger/debugger/debugger_test.go
+++ b/cmd/log-debugger/debugger/debugger_test.go
@@ -1,10 +1,9 @@
 package debugger
 
 import (
-	"path/filepath"
-	"runtime"
 	"testing"
 
+	"github.com/planetary-social/scuttlego/fixtures"
 	"github.com/stretchr/testify/require"
 )
 
@@ -14,7 +13,7 @@ const (
 )
 
 func TestLoadLog_LoadsLogFileCorrectly(t *testing.T) {
-	testLogFilename := filepath.Join(getTestFileDirectory(), testdataDirectoryName, testLogName)
+	testLogFilename := fixtures.TestFileRelativePath(testdataDirectoryName, testLogName)
 
 	log, err := LoadLog(testLogFilename)
 	require.NoError(t, err)
@@ -101,9 +100,4 @@ func TestLoadLog_LoadsLogFileCorrectly(t *testing.T) {
 		},
 		log,
 	)
-}
-
-func getTestFileDirectory() string {
-	_, filename, _, _ := runtime.Caller(0)
-	return filepath.Dir(filename)
 }

--- a/fixtures/fixtures.go
+++ b/fixtures/fixtures.go
@@ -7,6 +7,8 @@ import (
 	"math"
 	"math/rand"
 	"os"
+	"path/filepath"
+	"runtime"
 	"strconv"
 	"testing"
 	"time"
@@ -313,6 +315,13 @@ func Badger(t *testing.T) *badger.DB {
 	t.Cleanup(cleanup)
 
 	return db
+}
+
+func TestFileRelativePath(elem ...string) string {
+	_, filename, _, _ := runtime.Caller(1)
+	elems := []string{filepath.Dir(filename)}
+	elems = append(elems, elem...)
+	return filepath.Join(elems...)
 }
 
 type testingLogger struct {

--- a/service/adapters/badger/ban_list_repository.go
+++ b/service/adapters/badger/ban_list_repository.go
@@ -135,7 +135,7 @@ func (b BanListRepository) RemoveFeedMapping(ref refs.Feed) error {
 	}
 
 	if err := bucket.Delete(hash.Bytes()); err != nil {
-		return errors.Wrap(err, "bucket put failed")
+		return errors.Wrap(err, "bucket delete failed")
 	}
 
 	return nil

--- a/service/adapters/badger/pub_repository.go
+++ b/service/adapters/badger/pub_repository.go
@@ -90,7 +90,7 @@ func (r PubRepository) ListPubs(msgRef refs.Message) ([]refs.Identity, error) {
 			return errors.Wrap(err, "error determining key in bucket")
 		}
 
-		pubIdentityRef, err := refs.NewIdentity(string(pubIdentityKey.Bytes())) // todo is this a copy?
+		pubIdentityRef, err := refs.NewIdentity(string(pubIdentityKey.Bytes()))
 		if err != nil {
 			return errors.Wrap(err, "error creating pub identity ref")
 		}
@@ -121,7 +121,7 @@ func (r PubRepository) ListAddresses(pubIdentityRef refs.Identity) ([]PubAddress
 	var result []PubAddress
 
 	if err := byPubIdentityBucket.ForEach(func(item *badger.Item) error {
-		key, err := utils.NewKeyFromBytes(item.Key())
+		key, err := utils.NewKeyFromBytes(item.KeyCopy(nil))
 		if err != nil {
 			return errors.Wrap(err, "error creating a key")
 		}
@@ -188,7 +188,7 @@ func (r PubRepository) removeFromByPub(pubIdentityRef refs.Identity, msgRef refs
 	byPubIdentityBucket := utils.MustNewBucket(r.tx, r.bucketPathByPub(pubIdentityRef))
 
 	if err := byPubIdentityBucket.ForEach(func(item *badger.Item) error {
-		key, err := utils.NewKeyFromBytes(item.Key())
+		key, err := utils.NewKeyFromBytes(item.KeyCopy(nil))
 		if err != nil {
 			return errors.Wrap(err, "error creating a key")
 		}
@@ -201,7 +201,7 @@ func (r PubRepository) removeFromByPub(pubIdentityRef refs.Identity, msgRef refs
 		}
 
 		if itemMessageRef.Equal(msgRef) {
-			if err := r.tx.Delete(item.Key()); err != nil {
+			if err := r.tx.Delete(item.KeyCopy(nil)); err != nil {
 				return errors.Wrap(err, "delete error")
 			}
 		}

--- a/service/adapters/badger/social_graph_repository.go
+++ b/service/adapters/badger/social_graph_repository.go
@@ -86,14 +86,14 @@ func (s *SocialGraphRepository) GetContacts(node refs.Identity) ([]*feeds.Contac
 			return errors.Wrap(err, "error determining key in bucket")
 		}
 
-		targetRef, err := refs.NewIdentity(string(keyInBucket.Bytes())) // todo is this certainly a copy or are we reusing the slice illegally
+		targetRef, err := refs.NewIdentity(string(keyInBucket.Bytes()))
 		if err != nil {
 			return errors.Wrap(err, "could not create contact ref")
 		}
 
 		var contact *feeds.Contact
 		if err := item.Value(func(val []byte) error {
-			tmp, err := s.loadContact(node, targetRef, val) // todo is this a copy
+			tmp, err := s.loadContact(node, targetRef, val)
 			if err != nil {
 				return errors.Wrap(err, "failed to load the contact")
 			}

--- a/service/adapters/badger/utils/bucket.go
+++ b/service/adapters/badger/utils/bucket.go
@@ -86,7 +86,7 @@ func (b Bucket) ChildBucket(component KeyComponent) Bucket {
 
 func (b Bucket) DeleteBucket() error {
 	if err := b.ForEach(func(item *badger.Item) error { // todo don't prefech values? // todo do it faster somehow?
-		if err := b.tx.Delete(item.Key()); err != nil {
+		if err := b.tx.Delete(item.KeyCopy(nil)); err != nil {
 			return errors.Wrap(err, "delete error")
 		}
 		return nil

--- a/service/adapters/badger/wanted_feeds_repository.go
+++ b/service/adapters/badger/wanted_feeds_repository.go
@@ -53,7 +53,7 @@ func (b WantedFeedsRepository) GetWantedFeeds() (replication.WantedFeeds, error)
 
 	wantList, err := b.feedWantList.List()
 	if err != nil {
-		return replication.WantedFeeds{}, errors.Wrap(err, "could not get contacts")
+		return replication.WantedFeeds{}, errors.Wrap(err, "could not get the feed want list")
 	}
 
 	for _, feedRef := range wantList {
@@ -86,7 +86,7 @@ func (b WantedFeedsRepository) getFeedState(feed refs.Feed) (replication.FeedSta
 		if errors.Is(err, ErrFeedNotFound) {
 			return replication.NewEmptyFeedState(), nil
 		}
-		return replication.FeedState{}, errors.Wrap(err, "could not get a feed")
+		return replication.FeedState{}, errors.Wrapf(err, "could not load feed '%s'", feed)
 	}
 	seq, ok := f.Sequence()
 	if !ok {

--- a/service/adapters/mocks/raw_message_identifier.go
+++ b/service/adapters/mocks/raw_message_identifier.go
@@ -34,7 +34,11 @@ func (r *RawMessageIdentifierMock) LoadRawMessage(raw message.VerifiedRawMessage
 }
 
 func (r *RawMessageIdentifierMock) Mock(msg message.Message) {
-	r.v[hex.EncodeToString(msg.Raw().Bytes())] = msg
+	key := hex.EncodeToString(msg.Raw().Bytes())
+	if _, ok := r.v[key]; ok {
+		panic("message with identical raw bytes was already mocked")
+	}
+	r.v[key] = msg
 }
 
 func (r *RawMessageIdentifierMock) convert(msg message.Message) (message.MessageWithoutId, error) {


### PR DESCRIPTION
Badger keys can't be reused without copying them. Matt's database
somehow got corrupted after adding a feed to the ban list. While the
feed data was there all the referenced messages were not. All this data
is removed in transactions so the only explanation that I can think
about is that we are illegally reusing keys which seems to be true.

Added some unrelated tests that I wrote while looking for the bug. They
are unrelated because this bug is hard to test reliably.