### PR TITLE
Clarify how go-ssb is reused in the README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,14 +58,18 @@ If you find an issue, please report it on the [issue tracker][issue-tracker].
 
 ## Acknowledgements
 
-This implementation calls [go-ssb][go-ssb] and associated libraries under the
-hood. The elements which didn't have to be reimplemented from scratch thanks to
-that are mainly:
+This implementation depends on [go-ssb][go-ssb] and associated libraries under
+the hood. The elements which didn't have to be reimplemented from scratch thanks
+to that are mainly:
 
 - the handshake mechanism
 - the box stream protocol
 - the verification and signing of messages
 - broadcasting and receiving local UDP advertisements
+
+We are ever grateful for the work done by the authors and contributors of go-ssb
+and associated libraries as without them scuttlego most likely wouldn't have
+been completed.
 
 [ssb]: https://scuttlebutt.nz/
 

--- a/README.md
+++ b/README.md
@@ -58,8 +58,9 @@ If you find an issue, please report it on the [issue tracker][issue-tracker].
 
 ## Acknowledgements
 
-This implementation uses [go-ssb][go-ssb] and associated libraries under the
-hood. The elements which were reused are:
+This implementation calls [go-ssb][go-ssb] and associated libraries under the
+hood. The elements which didn't have to be reimplemented from scratch thanks to
+that are mainly:
 
 - the handshake mechanism
 - the box stream protocol
@@ -68,7 +69,7 @@ hood. The elements which were reused are:
 
 [ssb]: https://scuttlebutt.nz/
 
-[go-ssb]: https://github.com/cryptoscope/ssb
+[go-ssb]: https://github.com/ssbc/go-ssb
 
 [protocol-guide]: https://ssbc.github.io/scuttlebutt-protocol-guide/
 


### PR DESCRIPTION
I believe there was some confusion about this. This change clarifies
that go-ssb's code wasn't copied and instead scuttlego still relies on
go-ssb by calling it like every other library.