### PR TITLE
Enable linter for wireinject build tags

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,3 @@
+run:
+  build-tags:
+    - wireinject

--- a/di/inject_adapters.go
+++ b/di/inject_adapters.go
@@ -19,7 +19,6 @@ import (
 	"github.com/planetary-social/scuttlego/service/domain/transport/boxstream"
 )
 
-//nolint:unused
 var mockQueryAdaptersSet = wire.NewSet(
 	mocks.NewFeedRepositoryMock,
 	wire.Bind(new(queries.FeedRepository), new(*mocks.FeedRepositoryMock)),
@@ -31,7 +30,6 @@ var mockQueryAdaptersSet = wire.NewSet(
 	wire.Bind(new(queries.MessageRepository), new(*mocks.MessageRepositoryMock)),
 )
 
-//nolint:unused
 var blobsAdaptersSet = wire.NewSet(
 	newFilesystemStorage,
 	wire.Bind(new(blobReplication.BlobStorage), new(*blobs.FilesystemStorage)),
@@ -45,7 +43,6 @@ func newFilesystemStorage(logger logging.Logger, config Config) (*blobs.Filesyst
 	return blobs.NewFilesystemStorage(path.Join(config.GoSSBDataDirectory, "blobs"), logger)
 }
 
-//nolint:unused
 var adaptersSet = wire.NewSet(
 	adapters.NewCurrentTimeProvider,
 	wire.Bind(new(commands.CurrentTimeProvider), new(*adapters.CurrentTimeProvider)),
@@ -60,12 +57,4 @@ var adaptersSet = wire.NewSet(
 
 	invitesadapters.NewInviteDialer,
 	wire.Bind(new(invites.InviteDialer), new(*invitesadapters.InviteDialer)),
-)
-
-//nolint:unused
-var testAdaptersSet = wire.NewSet(
-	mocks.NewCurrentTimeProviderMock,
-	wire.Bind(new(commands.CurrentTimeProvider), new(*mocks.CurrentTimeProviderMock)),
-
-	mocks.NewBanListHasherMock,
 )

--- a/di/inject_application.go
+++ b/di/inject_application.go
@@ -12,7 +12,6 @@ import (
 	portsrpc "github.com/planetary-social/scuttlego/service/ports/rpc"
 )
 
-//nolint:unused
 var applicationSet = wire.NewSet(
 	wire.Struct(new(app.Application), "*"),
 
@@ -20,7 +19,6 @@ var applicationSet = wire.NewSet(
 	queriesSet,
 )
 
-//nolint:unused
 var commandsSet = wire.NewSet(
 	wire.Struct(new(app.Commands), "*"),
 
@@ -64,7 +62,6 @@ var commandsSet = wire.NewSet(
 	wire.Bind(new(portsrpc.AcceptTunnelConnectHandler), new(*commands.AcceptTunnelConnectHandler)),
 )
 
-//nolint:unused
 var queriesSet = wire.NewSet(
 	wire.Struct(new(app.Queries), "*"),
 

--- a/di/inject_badger.go
+++ b/di/inject_badger.go
@@ -14,7 +14,6 @@ import (
 	"github.com/planetary-social/scuttlego/service/domain/replication"
 )
 
-//nolint:unused
 var badgerUnpackTestDependenciesSet = wire.NewSet(
 	wire.FieldsOf(new(badgeradapters.TestAdaptersDependencies),
 		"BanListHasher",
@@ -27,12 +26,10 @@ var badgerUnpackTestDependenciesSet = wire.NewSet(
 	wire.Bind(new(badgeradapters.RawMessageIdentifier), new(*mocks.RawMessageIdentifierMock)),
 )
 
-//nolint:unused
 var badgerAdaptersSet = wire.NewSet(
 	badgeradapters.NewGarbageCollector,
 )
 
-//nolint:unused
 var badgerNoTxRepositoriesSet = wire.NewSet(
 	notx.NewNoTxBlobWantListRepository,
 	wire.Bind(new(blobReplication.WantListStorage), new(*notx.NoTxBlobWantListRepository)),
@@ -42,7 +39,6 @@ var badgerNoTxRepositoriesSet = wire.NewSet(
 	wire.Bind(new(replication.WantedFeedsRepository), new(*notx.NoTxWantedFeedsRepository)),
 )
 
-//nolint:unused
 var badgerRepositoriesSet = wire.NewSet(
 	badgeradapters.NewBanListRepository,
 	wire.Bind(new(commands.BanListRepository), new(*badgeradapters.BanListRepository)),
@@ -73,7 +69,6 @@ var badgerRepositoriesSet = wire.NewSet(
 	badgeradapters.NewBlobRepository,
 )
 
-//nolint:unused
 var badgerTestAdaptersDependenciesSet = wire.NewSet(
 	wire.Struct(new(badgeradapters.TestAdaptersDependencies), "*"),
 	mocks.NewBanListHasherMock,
@@ -81,7 +76,6 @@ var badgerTestAdaptersDependenciesSet = wire.NewSet(
 	mocks.NewRawMessageIdentifierMock,
 )
 
-//nolint:unused
 var badgerNoTxTestTransactionProviderSet = wire.NewSet(
 	notx.NewTestTxAdaptersFactoryTransactionProvider,
 	wire.Bind(new(notx.TransactionProvider), new(*notx.TestTxAdaptersFactoryTransactionProvider)),
@@ -89,13 +83,11 @@ var badgerNoTxTestTransactionProviderSet = wire.NewSet(
 	noTxTestTxAdaptersFactory,
 )
 
-//nolint:unused
 var testBadgerTransactionProviderSet = wire.NewSet(
 	badgeradapters.NewTestTransactionProvider,
 	testAdaptersFactory,
 )
 
-//nolint:unused
 var badgerTransactionProviderSet = wire.NewSet(
 	badgeradapters.NewCommandsTransactionProvider,
 	wire.Bind(new(commands.TransactionProvider), new(*badgeradapters.CommandsTransactionProvider)),
@@ -108,7 +100,6 @@ var badgerTransactionProviderSet = wire.NewSet(
 	badgerQueriesAdaptersFactory,
 )
 
-//nolint:unused
 var badgerNoTxTransactionProviderSet = wire.NewSet(
 	notx.NewTxAdaptersFactoryTransactionProvider,
 	wire.Bind(new(notx.TransactionProvider), new(*notx.TxAdaptersFactoryTransactionProvider)),

--- a/di/inject_config.go
+++ b/di/inject_config.go
@@ -8,7 +8,6 @@ import (
 	"github.com/planetary-social/scuttlego/service/domain/transport/boxstream"
 )
 
-//nolint:unused
 var extractFromConfigSet = wire.NewSet(
 	extractNetworkKeyFromConfig,
 	extractMessageHMACFromConfig,

--- a/di/inject_formats.go
+++ b/di/inject_formats.go
@@ -9,7 +9,6 @@ import (
 	"github.com/planetary-social/scuttlego/service/domain/feeds/formats"
 )
 
-//nolint:unused
 var formatsSet = wire.NewSet(
 	newFormats,
 

--- a/di/inject_migrations.go
+++ b/di/inject_migrations.go
@@ -7,7 +7,6 @@ import (
 	"github.com/planetary-social/scuttlego/service/app/commands"
 )
 
-//nolint:unused
 var migrationsSet = wire.NewSet(
 	migrations.NewRunner,
 	wire.Bind(new(commands.MigrationsRunner), new(*migrations.Runner)),
@@ -28,7 +27,6 @@ var migrationsSet = wire.NewSet(
 	migrationCommandsSet,
 )
 
-//nolint:unused
 var migrationCommandsSet = wire.NewSet(
 	wire.Struct(new(commands.Migrations), "*"),
 	commands.NewMigrationHandlerDeleteGoSSBRepositoryInOldFormat,

--- a/di/inject_networking.go
+++ b/di/inject_networking.go
@@ -14,7 +14,6 @@ import (
 	portsnetwork "github.com/planetary-social/scuttlego/service/ports/network"
 )
 
-//nolint:unused
 var networkingSet = wire.NewSet(
 	domaintransport.NewPeerInitializer,
 	wire.Bind(new(portsnetwork.ServerPeerInitializer), new(*domaintransport.PeerInitializer)),

--- a/di/inject_ports.go
+++ b/di/inject_ports.go
@@ -12,7 +12,6 @@ import (
 	portsrpc "github.com/planetary-social/scuttlego/service/ports/rpc"
 )
 
-//nolint:unused
 var portsSet = wire.NewSet(
 	mux.NewMux,
 

--- a/di/inject_pubsub.go
+++ b/di/inject_pubsub.go
@@ -9,7 +9,6 @@ import (
 	"github.com/planetary-social/scuttlego/service/domain/transport/rpc"
 )
 
-//nolint:unused
 var pubSubSet = wire.NewSet(
 	requestPubSubSet,
 	messagePubSubSet,
@@ -17,26 +16,22 @@ var pubSubSet = wire.NewSet(
 	roomAttendantEventPubSubSet,
 )
 
-//nolint:unused
 var requestPubSubSet = wire.NewSet(
 	pubsub.NewRequestPubSub,
 	wire.Bind(new(rpc.RequestHandler), new(*pubsub.RequestPubSub)),
 )
 
-//nolint:unused
 var messagePubSubSet = wire.NewSet(
 	pubsub.NewMessagePubSub,
 	wire.Bind(new(queries.MessageSubscriber), new(*pubsub.MessagePubSub)),
 )
 
-//nolint:unused
 var blobDownloadedPubSubSet = wire.NewSet(
 	pubsub.NewBlobDownloadedPubSub,
 	wire.Bind(new(queries.BlobDownloadedSubscriber), new(*pubsub.BlobDownloadedPubSub)),
 	wire.Bind(new(blobReplication.BlobDownloadedPublisher), new(*pubsub.BlobDownloadedPubSub)),
 )
 
-//nolint:unused
 var roomAttendantEventPubSubSet = wire.NewSet(
 	pubsub.NewRoomAttendantEventPubSub,
 	wire.Bind(new(rooms.AttendantEventPublisher), new(*pubsub.RoomAttendantEventPubSub)),


### PR DESCRIPTION
Removed not needed ignore tags and one set that was found to be unused.