### PR TITLE
Delted messages are removed from receive log

### DIFF
--- a/service/adapters/badger/feed_repository.go
+++ b/service/adapters/badger/feed_repository.go
@@ -208,6 +208,10 @@ func (b FeedRepository) removeMessageData(ref refs.Message) error {
 		return errors.Wrap(err, "failed to remove from pub repository")
 	}
 
+	if err := b.receiveLog.Delete(ref); err != nil {
+		return errors.Wrap(err, "failed to remove from receive log")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
The receive log used to break when messages were removed. Alternative
solution would be to skip messages not found in the message repository
but I can't find a solid reason for not removing receive log entries and
going with that approach.