### PR TITLE
Fix receive log data corruption on migration

### DIFF
--- a/service/app/commands/handler_migration_import_data_from_gossb_test.go
+++ b/service/app/commands/handler_migration_import_data_from_gossb_test.go
@@ -402,6 +402,101 @@ func TestMigrationHandlerImportDataFromGoSSB_SequenceIsNotSavedIfItIsNotSignific
 	)
 }
 
+func TestMigrationHandlerImportDataFromGoSSB_ReceiveLogIsNotWronglyOverridenByFollowUpMessages(t *testing.T) {
+	tc, err := di.BuildTestCommands(t)
+	require.NoError(t, err)
+
+	directory := fixtures.SomeString()
+	saveResumeFromSequenceFn := newSaveResumeFromSequenceFnMock()
+
+	cmd, err := commands.NewImportDataFromGoSSB(directory, nil, saveResumeFromSequenceFn.Fn)
+	require.NoError(t, err)
+
+	feed := fixtures.SomeRefFeed()
+	seq := message.NewFirstSequence()
+
+	msg1ReceiveLogSequence := common.MustNewReceiveLogSequence(1)
+	msg1 := mockGoSSBMessageWithIdFeedAndSequence(
+		t,
+		fixtures.SomeRefMessage(),
+		feed,
+		seq,
+	)
+
+	msg2ReceiveLogSequence := common.MustNewReceiveLogSequence(2)
+	msg2 := mockGoSSBMessageWithIdFeedAndSequence(
+		t,
+		fixtures.SomeRefMessage(),
+		feed,
+		seq,
+	)
+
+	tc.GoSSBRepoReader.MockGetMessages(
+		[]commands.GoSSBMessageOrError{
+			{
+				Value: commands.GoSSBMessage{
+					ReceiveLogSequence: msg1ReceiveLogSequence,
+					Message:            msg1,
+				},
+				Err: nil,
+			},
+			{
+				Value: commands.GoSSBMessage{
+					ReceiveLogSequence: msg2ReceiveLogSequence,
+					Message:            msg2,
+				},
+				Err: nil,
+			},
+		},
+	)
+
+	ctx := fixtures.TestContext(t)
+	result, err := tc.MigrationImportDataFromGoSSB.Handle(ctx, cmd)
+	require.NoError(t, err)
+
+	require.Equal(t,
+		commands.ImportDataFromGoSSBResult{
+			Successes: 1,
+			Errors:    1,
+		},
+		result,
+	)
+
+	require.Equal(t,
+		[]mocks.GoSSBRepoReaderMockGetMessagesCall{
+			{
+				Directory:          directory,
+				ResumeFromSequence: nil,
+			},
+		},
+		tc.GoSSBRepoReader.GoSSBRepoReaderMockGetMessagesCalls,
+	)
+
+	require.Equal(
+		t,
+		[]mocks.FeedRepositoryMockUpdateFeedIgnoringReceiveLogCall{
+			{
+				Feed: feed,
+				MessagesToPersist: []refs.Message{
+					refs.MustNewMessage(msg1.Key().String()),
+				},
+			},
+		},
+		tc.FeedRepository.UpdateFeedIgnoringReceiveLogCalls(),
+	)
+
+	require.Equal(
+		t,
+		[]mocks.ReceiveLogRepositoryPutUnderSpecificSequenceCall{
+			{
+				Id:       refs.MustNewMessage(msg1.Key().String()),
+				Sequence: msg1ReceiveLogSequence,
+			},
+		},
+		tc.ReceiveLog.PutUnderSpecificSequenceCalls,
+	)
+}
+
 func mockGoSSBMessage(t *testing.T) gossbrefs.Message {
 	key, err := gossbrefs.ParseMessageRef(fixtures.SomeRefMessage().String())
 	require.NoError(t, err)
@@ -413,6 +508,33 @@ func mockGoSSBMessage(t *testing.T) gossbrefs.Message {
 		key:    key,
 		author: author,
 		seq:    1,
+	}
+}
+
+func mockGoSSBMessageWithIdFeedAndSequence(
+	t *testing.T,
+	id refs.Message,
+	feed refs.Feed,
+	sequence message.Sequence,
+) gossbrefs.Message {
+	key, err := gossbrefs.ParseMessageRef(id.String())
+	require.NoError(t, err)
+
+	var previous *gossbrefs.MessageRef
+	if !sequence.IsFirst() {
+		tmp, err := gossbrefs.ParseMessageRef(fixtures.SomeRefMessage().String())
+		require.NoError(t, err)
+		previous = &tmp
+	}
+
+	author, err := gossbrefs.ParseFeedRef(feed.String())
+	require.NoError(t, err)
+
+	return mockMessage{
+		key:      key,
+		author:   author,
+		previous: previous,
+		seq:      int64(sequence.Int()),
 	}
 }
 

--- a/service/domain/feeds/feed.go
+++ b/service/domain/feeds/feed.go
@@ -137,6 +137,14 @@ func (f *Feed) PopForPersisting() []MessageToPersist {
 	return f.messagesToSave
 }
 
+func (f *Feed) MessagesThatWillBePersisted() []refs.Message {
+	var result []refs.Message
+	for _, msg := range f.messagesToSave {
+		result = append(result, msg.Message().Id())
+	}
+	return result
+}
+
 // todo ignore repeated calls to follow someone if the current state of the feed suggests that this is already done (indempotency)
 func (f *Feed) onNewMessage(msg message.Message) error {
 	contacts := f.getContactsToSave(msg)


### PR DESCRIPTION
Ignored messages were treated as successes and put in the receive log. The receive log would then break because those messages didn't actually exist in the database.

Fixes https://github.com/planetary-social/scuttlego/issues/200.

In reality we should solve this at the domain level and this bug stems from the fact that we didn't.