### PR TITLE
Detect and handle forks during migration

### DIFF
--- a/service/adapters/mocks/feed_repository.go
+++ b/service/adapters/mocks/feed_repository.go
@@ -31,6 +31,11 @@ type FeedRepositoryMockUpdateFeedIgnoringReceiveLogCall struct {
 	MessagesToPersist []refs.Message
 }
 
+type FeedRepositoryMockRemoveMessagesAtOrAboveSequenceCall struct {
+	Feed refs.Feed
+	Seq  message.Sequence
+}
+
 type FeedRepositoryMock struct {
 	getMessagesCalls       []FeedRepositoryMockGetMessagesCall
 	GetMessagesReturnValue []message.Message
@@ -47,7 +52,8 @@ type FeedRepositoryMock struct {
 
 	CountReturnValue int
 
-	lock sync.Mutex
+	lock                                 sync.Mutex
+	RemoveMessagesAtOrAboveSequenceCalls []FeedRepositoryMockRemoveMessagesAtOrAboveSequenceCall
 }
 
 func NewFeedRepositoryMock() *FeedRepositoryMock {
@@ -87,6 +93,14 @@ func (m *FeedRepositoryMock) UpdateFeedIgnoringReceiveLog(ref refs.Feed, f comma
 
 func (m *FeedRepositoryMock) DeleteFeed(ref refs.Feed) error {
 	return errors.New("not implemented")
+}
+
+func (m *FeedRepositoryMock) RemoveMessagesAtOrAboveSequence(ref refs.Feed, sequence message.Sequence) error {
+	m.RemoveMessagesAtOrAboveSequenceCalls = append(m.RemoveMessagesAtOrAboveSequenceCalls, FeedRepositoryMockRemoveMessagesAtOrAboveSequenceCall{
+		Feed: ref,
+		Seq:  sequence,
+	})
+	return nil
 }
 
 func (m *FeedRepositoryMock) GetMessages(id refs.Feed, seq *message.Sequence, limit *int) ([]message.Message, error) {

--- a/service/app/commands/common.go
+++ b/service/app/commands/common.go
@@ -83,6 +83,14 @@ type FeedRepository interface {
 
 	// DeleteFeed removes the feed with all associated data.
 	DeleteFeed(ref refs.Feed) error
+
+	// GetMessage returns a message with a given sequence from the specified
+	// feed.
+	GetMessage(ref refs.Feed, sequence message.Sequence) (message.Message, error)
+
+	// RemoveMessagesAtOrAboveSequence removes all feed messages with sequence
+	// greater or equal to the given one.
+	RemoveMessagesAtOrAboveSequence(ref refs.Feed, sequence message.Sequence) error
 }
 
 type SocialGraphRepository interface {

--- a/service/app/common/common.go
+++ b/service/app/common/common.go
@@ -41,4 +41,5 @@ func (r ReceiveLogSequence) String() string {
 var (
 	ErrReceiveLogEntryNotFound = errors.New("receive log entry not found")
 	ErrFeedNotFound            = errors.New("feed not found")
+	ErrFeedMessageNotFound     = errors.New("feed message not found")
 )


### PR DESCRIPTION
Sometimes messages are quietly forked and we don't know which is the
correct one. If we detect a message conflicts with an existing message
we drop all messages with sequence >= sequence of that message so let
the conflic resync from the network.

Related to https://github.com/planetary-social/scuttlego/issues/197.