### PR TITLE
Add constructors to all commands and queries

### DIFF
--- a/service/app/commands/handler_accept_new_peer.go
+++ b/service/app/commands/handler_accept_new_peer.go
@@ -1,11 +1,27 @@
 package commands
 
 import (
+	"github.com/boreq/errors"
 	"github.com/planetary-social/scuttlego/service/domain/transport"
 )
 
 type AcceptNewPeer struct {
-	Peer transport.Peer
+	peer transport.Peer
+}
+
+func NewAcceptNewPeer(peer transport.Peer) (AcceptNewPeer, error) {
+	if peer.IsZero() {
+		return AcceptNewPeer{}, errors.New("zero value of peer")
+	}
+	return AcceptNewPeer{peer: peer}, nil
+}
+
+func (a AcceptNewPeer) Peer() transport.Peer {
+	return a.peer
+}
+
+func (a AcceptNewPeer) IsZero() bool {
+	return a.peer.IsZero()
 }
 
 type AcceptNewPeerHandler struct {
@@ -21,6 +37,10 @@ func NewAcceptNewPeerHandler(
 }
 
 func (h *AcceptNewPeerHandler) Handle(cmd AcceptNewPeer) error {
-	h.peerHandler.HandleNewPeer(cmd.Peer)
+	if cmd.IsZero() {
+		return errors.New("zero value of cmd")
+	}
+
+	h.peerHandler.HandleNewPeer(cmd.Peer())
 	return nil
 }

--- a/service/app/commands/handler_add_blob.go
+++ b/service/app/commands/handler_add_blob.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"io"
 
+	"github.com/boreq/errors"
 	"github.com/planetary-social/scuttlego/service/domain/refs"
 )
 
@@ -11,7 +12,22 @@ type BlobCreator interface {
 }
 
 type CreateBlob struct {
-	Reader io.Reader
+	reader io.Reader
+}
+
+func NewCreateBlob(reader io.Reader) (CreateBlob, error) {
+	if reader == nil {
+		return CreateBlob{}, errors.New("zero value of reader")
+	}
+	return CreateBlob{reader: reader}, nil
+}
+
+func (c CreateBlob) Reader() io.Reader {
+	return c.reader
+}
+
+func (c CreateBlob) IsZero() bool {
+	return c == CreateBlob{}
 }
 
 type CreateBlobHandler struct {
@@ -27,5 +43,8 @@ func NewCreateBlobHandler(
 }
 
 func (h *CreateBlobHandler) Handle(cmd CreateBlob) (refs.Blob, error) {
-	return h.creator.Create(cmd.Reader)
+	if cmd.IsZero() {
+		return refs.Blob{}, errors.New("zero value of cmd")
+	}
+	return h.creator.Create(cmd.Reader())
 }

--- a/service/app/commands/handler_add_to_ban_list.go
+++ b/service/app/commands/handler_add_to_ban_list.go
@@ -19,6 +19,10 @@ func NewAddToBanList(hash bans.Hash) (AddToBanList, error) {
 	return AddToBanList{hash: hash}, nil
 }
 
+func (c AddToBanList) Hash() bans.Hash {
+	return c.hash
+}
+
 func (c AddToBanList) IsZero() bool {
 	return c.hash.IsZero()
 }
@@ -41,10 +45,10 @@ func (h *AddToBanListHandler) Handle(cmd AddToBanList) error {
 	}
 
 	if err := h.transaction.Transact(func(adapters Adapters) error {
-		if err := adapters.BanList.Add(cmd.hash); err != nil {
+		if err := adapters.BanList.Add(cmd.Hash()); err != nil {
 			return errors.Wrap(err, "could not add the hash to the ban list")
 		}
-		return h.tryToRemoveTheBannedThing(adapters, cmd.hash)
+		return h.tryToRemoveTheBannedThing(adapters, cmd.Hash())
 	}); err != nil {
 		return errors.Wrap(err, "transaction failed")
 	}

--- a/service/app/commands/handler_connect.go
+++ b/service/app/commands/handler_connect.go
@@ -7,17 +7,40 @@ import (
 	"github.com/planetary-social/scuttlego/service/domain/network"
 )
 
-// Connect tries to initiate the connection to the specified node. This is most likely useful when you want to
-// explicitly stimulate the program to talk to a specific node. Normally connections are initiated and managed
-// automatically. Executing this command doesn't necessarily mean that a new connection will be established, for
-// example the underlying implementation may decide not to do this if the connection with the specified identity
-// already exists.
+// Connect tries to initiate the connection to the specified node. This is most
+// likely useful when you want to explicitly stimulate the program to talk to a
+// specific node. Normally connections are initiated and managed automatically.
+// Executing this command doesn't necessarily mean that a new connection will be
+// established, for example the underlying implementation may decide not to do
+// this if the connection with the specified identity already exists.
 type Connect struct {
-	// Remote is the identity of the remote node.
-	Remote identity.Public
+	// remote is the identity of the remote node.
+	remote identity.Public
 
-	// Address is the address of the remote node.
-	Address network.Address
+	// address is the address of the remote node.
+	address network.Address
+}
+
+func NewConnect(remote identity.Public, address network.Address) (Connect, error) {
+	if remote.IsZero() {
+		return Connect{}, errors.New("zero value of remote")
+	}
+	if address.IsZero() {
+		return Connect{}, errors.New("zero value of address")
+	}
+	return Connect{remote: remote, address: address}, nil
+}
+
+func (c Connect) Remote() identity.Public {
+	return c.remote
+}
+
+func (c Connect) Address() network.Address {
+	return c.address
+}
+
+func (c Connect) IsZero() bool {
+	return c.remote.IsZero()
 }
 
 type ConnectHandler struct {
@@ -36,9 +59,12 @@ func NewConnectHandler(
 }
 
 func (h *ConnectHandler) Handle(cmd Connect) error {
-	if err := h.peerManager.Connect(cmd.Remote, cmd.Address); err != nil {
-		return errors.Wrap(err, "error initiating the connection")
+	if cmd.IsZero() {
+		return errors.New("zero value of cmd")
 	}
 
+	if err := h.peerManager.Connect(cmd.Remote(), cmd.Address()); err != nil {
+		return errors.Wrap(err, "connect error")
+	}
 	return nil
 }

--- a/service/app/commands/handler_create_wants.go
+++ b/service/app/commands/handler_create_wants.go
@@ -10,9 +10,6 @@ type BlobReplicationManager interface {
 	HandleIncomingCreateWantsRequest(ctx context.Context) (<-chan messages.BlobWithSizeOrWantDistance, error)
 }
 
-type CreateWants struct {
-}
-
 type CreateWantsHandler struct {
 	manager BlobReplicationManager
 }
@@ -23,6 +20,6 @@ func NewCreateWantsHandler(manager BlobReplicationManager) *CreateWantsHandler {
 	}
 }
 
-func (h *CreateWantsHandler) Handle(ctx context.Context, cmd CreateWants) (<-chan messages.BlobWithSizeOrWantDistance, error) {
+func (h *CreateWantsHandler) Handle(ctx context.Context) (<-chan messages.BlobWithSizeOrWantDistance, error) {
 	return h.manager.HandleIncomingCreateWantsRequest(ctx)
 }

--- a/service/app/commands/handler_migration_delete_gossb_repository_in_old_format.go
+++ b/service/app/commands/handler_migration_delete_gossb_repository_in_old_format.go
@@ -23,6 +23,10 @@ func NewDeleteGoSSBRepositoryInOldFormat(
 	}, nil
 }
 
+func (cmd DeleteGoSSBRepositoryInOldFormat) Directory() string {
+	return cmd.directory
+}
+
 func (cmd DeleteGoSSBRepositoryInOldFormat) IsZero() bool {
 	return cmd == DeleteGoSSBRepositoryInOldFormat{}
 }
@@ -47,13 +51,13 @@ func (h MigrationHandlerDeleteGoSSBRepositoryInOldFormat) Handle(ctx context.Con
 		return errors.New("zero value of command")
 	}
 
-	canRead, err := h.canReadData(ctx, cmd.directory)
+	canRead, err := h.canReadData(ctx, cmd.Directory())
 	if err != nil {
 		return errors.Wrap(err, "error checking if data can be read")
 	}
 
 	if !canRead {
-		if err := os.RemoveAll(cmd.directory); err != nil {
+		if err := os.RemoveAll(cmd.Directory()); err != nil {
 			return errors.Wrap(err, "error removing the directory")
 		}
 	}

--- a/service/app/commands/handler_process_new_local_discovery.go
+++ b/service/app/commands/handler_process_new_local_discovery.go
@@ -7,8 +7,33 @@ import (
 )
 
 type ProcessNewLocalDiscovery struct {
-	Remote  identity.Public
-	Address network.Address
+	remote  identity.Public
+	address network.Address
+}
+
+func NewProcessNewLocalDiscovery(
+	remote identity.Public,
+	address network.Address,
+) (ProcessNewLocalDiscovery, error) {
+	if remote.IsZero() {
+		return ProcessNewLocalDiscovery{}, errors.New("zero value of remote")
+	}
+	if address.IsZero() {
+		return ProcessNewLocalDiscovery{}, errors.New("zero value of address")
+	}
+	return ProcessNewLocalDiscovery{remote: remote, address: address}, nil
+}
+
+func (p ProcessNewLocalDiscovery) Remote() identity.Public {
+	return p.remote
+}
+
+func (p ProcessNewLocalDiscovery) Address() network.Address {
+	return p.address
+}
+
+func (p ProcessNewLocalDiscovery) IsZero() bool {
+	return p.remote.IsZero()
 }
 
 type ProcessNewLocalDiscoveryHandler struct {
@@ -22,9 +47,12 @@ func NewProcessNewLocalDiscoveryHandler(peerManager PeerManager) *ProcessNewLoca
 }
 
 func (h *ProcessNewLocalDiscoveryHandler) Handle(cmd ProcessNewLocalDiscovery) error {
-	if err := h.peerManager.ProcessNewLocalDiscovery(cmd.Remote, cmd.Address); err != nil {
-		return errors.Wrap(err, "error calling peer manager")
+	if cmd.IsZero() {
+		return errors.New("zero value of cmd")
 	}
 
+	if err := h.peerManager.ProcessNewLocalDiscovery(cmd.Remote(), cmd.Address()); err != nil {
+		return errors.Wrap(err, "error calling peer manager")
+	}
 	return nil
 }

--- a/service/app/commands/handler_publish_raw.go
+++ b/service/app/commands/handler_publish_raw.go
@@ -19,6 +19,10 @@ func NewPublishRaw(content []byte) (PublishRaw, error) {
 	return PublishRaw{content: content}, nil
 }
 
+func (cmd PublishRaw) Content() []byte {
+	return cmd.content
+}
+
 func (cmd PublishRaw) IsZero() bool {
 	return len(cmd.content) == 0
 }
@@ -39,7 +43,11 @@ func NewPublishRawHandler(
 }
 
 func (h *PublishRawHandler) Handle(cmd PublishRaw) (refs.Message, error) {
-	content, err := message.NewRawContent(cmd.content)
+	if cmd.IsZero() {
+		return refs.Message{}, errors.New("zero value of cmd")
+	}
+
+	content, err := message.NewRawContent(cmd.Content())
 	if err != nil {
 		return refs.Message{}, errors.Wrap(err, "could not create raw message content")
 	}

--- a/service/app/commands/handler_publish_raw_as_identity.go
+++ b/service/app/commands/handler_publish_raw_as_identity.go
@@ -28,6 +28,14 @@ func NewPublishRawAsIdentity(content []byte, identity identity.Private) (Publish
 	return PublishRawAsIdentity{content: content, identity: identity}, nil
 }
 
+func (cmd PublishRawAsIdentity) Content() []byte {
+	return cmd.content
+}
+
+func (cmd PublishRawAsIdentity) Identity() identity.Private {
+	return cmd.identity
+}
+
 func (cmd PublishRawAsIdentity) IsZero() bool {
 	return cmd.identity.IsZero()
 }
@@ -49,12 +57,12 @@ func (h *PublishRawAsIdentityHandler) Handle(cmd PublishRawAsIdentity) (refs.Mes
 		return refs.Message{}, errors.New("zero value of cmd")
 	}
 
-	content, err := message.NewRawContent(cmd.content)
+	content, err := message.NewRawContent(cmd.Content())
 	if err != nil {
 		return refs.Message{}, errors.Wrap(err, "could not create raw message content")
 	}
 
-	ref, err := h.publisher.Publish(cmd.identity, content)
+	ref, err := h.publisher.Publish(cmd.Identity(), content)
 	if err != nil {
 		return refs.Message{}, errors.Wrap(err, "publishing error")
 	}

--- a/service/app/commands/handler_raw_message.go
+++ b/service/app/commands/handler_raw_message.go
@@ -29,6 +29,10 @@ func NewRawMessageHandler(
 }
 
 func (h *RawMessageHandler) Handle(rawMsg message.RawMessage) error {
+	if rawMsg.IsZero() {
+		return errors.New("zero value of raw message")
+	}
+
 	msg, err := h.identifier.VerifyRawMessage(rawMsg)
 	if err != nil {
 		return errors.Wrap(err, "failed to identify the raw message")

--- a/service/app/commands/handler_redeem_invite.go
+++ b/service/app/commands/handler_redeem_invite.go
@@ -14,7 +14,22 @@ type InviteRedeemer interface {
 }
 
 type RedeemInvite struct {
-	Invite invites.Invite
+	invite invites.Invite
+}
+
+func NewRedeemInvite(invite invites.Invite) (RedeemInvite, error) {
+	if invite.IsZero() {
+		return RedeemInvite{}, errors.New("zero value of invite")
+	}
+	return RedeemInvite{invite: invite}, nil
+}
+
+func (r RedeemInvite) Invite() invites.Invite {
+	return r.invite
+}
+
+func (r RedeemInvite) IsZero() bool {
+	return r.invite.IsZero()
 }
 
 type RedeemInviteHandler struct {
@@ -36,7 +51,11 @@ func NewRedeemInviteHandler(
 }
 
 func (h *RedeemInviteHandler) Handle(ctx context.Context, cmd RedeemInvite) error {
-	if err := h.redeemer.RedeemInvite(ctx, cmd.Invite, h.local.Public()); err != nil {
+	if cmd.IsZero() {
+		return errors.New("zero value of cmd")
+	}
+
+	if err := h.redeemer.RedeemInvite(ctx, cmd.Invite(), h.local.Public()); err != nil {
 		if errors.Is(err, invites.ErrAlreadyFollowing) {
 			h.logger.Debug("pub reported that it is already following the user")
 			return nil

--- a/service/app/commands/handler_redeem_invite_test.go
+++ b/service/app/commands/handler_redeem_invite_test.go
@@ -16,7 +16,9 @@ func TestRedeemInviteHandler(t *testing.T) {
 
 	invite := fixtures.SomeInvite()
 	ctx := fixtures.TestContext(t)
-	cmd := commands.RedeemInvite{Invite: invite}
+
+	cmd, err := commands.NewRedeemInvite(invite)
+	require.NoError(t, err)
 
 	t.Run("no_error", func(t *testing.T) {
 		tc.InviteRedeemer.RedeemInviteErr = nil

--- a/service/app/commands/handler_remove_from_ban_list.go
+++ b/service/app/commands/handler_remove_from_ban_list.go
@@ -16,6 +16,10 @@ func NewRemoveFromBanList(hash bans.Hash) (RemoveFromBanList, error) {
 	return RemoveFromBanList{hash: hash}, nil
 }
 
+func (c RemoveFromBanList) Hash() bans.Hash {
+	return c.hash
+}
+
 func (c RemoveFromBanList) IsZero() bool {
 	return c.hash.IsZero()
 }
@@ -36,7 +40,7 @@ func (h *RemoveFromBanListHandler) Handle(cmd RemoveFromBanList) error {
 	}
 
 	if err := h.transaction.Transact(func(adapters Adapters) error {
-		if err := adapters.BanList.Remove(cmd.hash); err != nil {
+		if err := adapters.BanList.Remove(cmd.Hash()); err != nil {
 			return errors.Wrap(err, "could not remove the hash from the ban list")
 		}
 		return nil

--- a/service/app/queries/handler_get_blob.go
+++ b/service/app/queries/handler_get_blob.go
@@ -14,15 +14,38 @@ type BlobStorage interface {
 }
 
 type GetBlob struct {
-	Id refs.Blob
+	id refs.Blob
 
 	// Size is the expected size of the blob in bytes. If the blob is not
 	// exactly this size then an error is returned.
-	Size *blobs.Size
+	size *blobs.Size
 
 	// Max is the Maximum size of the blob in bytes. If the blob is larger then
 	// an error is returned.
-	Max *blobs.Size
+	max *blobs.Size
+}
+
+func NewGetBlob(id refs.Blob, size *blobs.Size, max *blobs.Size) (GetBlob, error) {
+	if id.IsZero() {
+		return GetBlob{}, errors.New("zero value of id")
+	}
+	return GetBlob{id: id, size: size, max: max}, nil
+}
+
+func (g GetBlob) Id() refs.Blob {
+	return g.id
+}
+
+func (g GetBlob) Size() *blobs.Size {
+	return g.size
+}
+
+func (g GetBlob) Max() *blobs.Size {
+	return g.max
+}
+
+func (g GetBlob) IsZero() bool {
+	return g.id.IsZero()
 }
 
 type GetBlobHandler struct {
@@ -36,24 +59,28 @@ func NewGetBlobHandler(storage BlobStorage) (*GetBlobHandler, error) {
 }
 
 func (h *GetBlobHandler) Handle(query GetBlob) (io.ReadCloser, error) {
-	if query.Size != nil || query.Max != nil {
-		blobSize, err := h.storage.Size(query.Id)
+	if query.IsZero() {
+		return nil, errors.New("zero value of query")
+	}
+
+	if query.Size() != nil || query.Max() != nil {
+		blobSize, err := h.storage.Size(query.Id())
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to get the blob size")
 		}
 
-		if query.Size != nil {
-			if blobSize != *query.Size {
+		if query.Size() != nil {
+			if blobSize != *query.Size() {
 				return nil, errors.New("blob size doesn't match the provided size")
 			}
 		}
 
-		if query.Max != nil {
-			if blobSize.Above(*query.Max) {
+		if query.Max() != nil {
+			if blobSize.Above(*query.Max()) {
 				return nil, errors.New("blob is larger than the provided max size")
 			}
 		}
 	}
 
-	return h.storage.Get(query.Id)
+	return h.storage.Get(query.Id())
 }

--- a/service/app/queries/handler_published_log.go
+++ b/service/app/queries/handler_published_log.go
@@ -12,7 +12,15 @@ type PublishedLog struct {
 	// numbers greater than the given receive log sequence are returned. If a
 	// message has multiple receive log sequence numbers the higher one is used.
 	// Pass nil to get all messages.
-	LastSeq *common.ReceiveLogSequence
+	lastSeq *common.ReceiveLogSequence
+}
+
+func NewPublishedLog(lastSeq *common.ReceiveLogSequence) (PublishedLog, error) {
+	return PublishedLog{lastSeq: lastSeq}, nil
+}
+
+func (p PublishedLog) LastSeq() *common.ReceiveLogSequence {
+	return p.lastSeq
 }
 
 type PublishedLogHandler struct {
@@ -68,7 +76,7 @@ func (h *PublishedLogHandler) Handle(query PublishedLog) ([]LogMessage, error) {
 				return errors.Wrap(err, "error getting highest receive log sequence")
 			}
 
-			if query.LastSeq != nil && query.LastSeq.Int() >= receiveLogSequence.Int() {
+			if query.LastSeq != nil && query.LastSeq().Int() >= receiveLogSequence.Int() {
 				break
 			}
 

--- a/service/app/queries/handler_rooms_list_aliases.go
+++ b/service/app/queries/handler_rooms_list_aliases.go
@@ -70,7 +70,7 @@ func NewRoomsListAliasesHandler(
 
 func (h *RoomsListAliasesHandler) Handle(ctx context.Context, query RoomsListAliases) ([]aliases.Alias, error) {
 	if query.IsZero() {
-		return nil, errors.New("zero value of command")
+		return nil, errors.New("zero value of query")
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)

--- a/service/domain/invites/invite.go
+++ b/service/domain/invites/invite.go
@@ -81,3 +81,7 @@ func (i Invite) Address() network.Address {
 func (i Invite) SecretKeySeed() []byte {
 	return i.secretKeySeed
 }
+
+func (i Invite) IsZero() bool {
+	return i.remote.IsZero()
+}


### PR DESCRIPTION
Right now it is a mess and we can't decide if they should be there or not. Given that this is the main place that guards the program from bad "user" input we should make sure we have the constructors in place.