### PR TITLE
Set correct response body type

### DIFF
--- a/fixtures/fixtures.go
+++ b/fixtures/fixtures.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/dgraph-io/badger/v3"
+	"github.com/planetary-social/scuttlego/internal"
 	"github.com/planetary-social/scuttlego/logging"
 	"github.com/planetary-social/scuttlego/service/app/common"
 	"github.com/planetary-social/scuttlego/service/domain/bans"
@@ -127,11 +128,12 @@ func SomeContent() message.Content {
 }
 
 func SomeMessageBodyType() transport.MessageBodyType {
-	if rand.Int()%2 == 0 {
-		return transport.MessageBodyTypeJSON
-	} else {
-		return transport.MessageBodyTypeBinary
+	choices := []transport.MessageBodyType{
+		transport.MessageBodyTypeBinary,
+		transport.MessageBodyTypeString,
+		transport.MessageBodyTypeJSON,
 	}
+	return internal.RandomElement(choices)
 }
 
 func SomeSequence() message.Sequence {

--- a/internal/slice.go
+++ b/internal/slice.go
@@ -16,3 +16,8 @@ func ShuffleSlice[T any](slice []T) {
 		slice[i], slice[j] = slice[j], slice[i]
 	})
 }
+
+func RandomElement[T any](slice []T) T {
+	return slice[rand.Intn(len(slice))]
+
+}

--- a/service/domain/mocks/connection.go
+++ b/service/domain/mocks/connection.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/planetary-social/scuttlego/fixtures"
 	"github.com/planetary-social/scuttlego/service/domain/transport/rpc"
+	"github.com/planetary-social/scuttlego/service/domain/transport/rpc/transport"
 )
 
 type ConnectionMock struct {
@@ -84,7 +85,7 @@ func newResponseStreamMock(chReceive chan rpc.ResponseWithError) *responseStream
 	}
 }
 
-func (r responseStreamMock) WriteMessage(body []byte) error {
+func (r responseStreamMock) WriteMessage(body []byte, bodyType transport.MessageBodyType) error {
 	return nil
 }
 

--- a/service/domain/replication/ebt/adapters.go
+++ b/service/domain/replication/ebt/adapters.go
@@ -11,6 +11,7 @@ import (
 	"github.com/planetary-social/scuttlego/service/domain/replication"
 	"github.com/planetary-social/scuttlego/service/domain/transport/rpc"
 	"github.com/planetary-social/scuttlego/service/domain/transport/rpc/mux"
+	"github.com/planetary-social/scuttlego/service/domain/transport/rpc/transport"
 )
 
 type OutgoingStreamAdapter struct {
@@ -76,11 +77,11 @@ func (r *OutgoingStreamAdapter) SendNotes(notes messages.EbtReplicateNotes) erro
 	if err != nil {
 		return errors.Wrap(err, "json marshal error")
 	}
-	return r.stream.WriteMessage(j)
+	return r.stream.WriteMessage(j, transport.MessageBodyTypeJSON)
 }
 
 func (r *OutgoingStreamAdapter) SendMessage(msg *message.Message) error {
-	return r.stream.WriteMessage(msg.Raw().Bytes())
+	return r.stream.WriteMessage(msg.Raw().Bytes(), transport.MessageBodyTypeJSON)
 }
 
 type IncomingStreamAdapter struct {
@@ -137,11 +138,11 @@ func (s IncomingStreamAdapter) SendNotes(notes messages.EbtReplicateNotes) error
 	if err != nil {
 		return errors.Wrap(err, "json marshal error")
 	}
-	return s.stream.WriteMessage(j)
+	return s.stream.WriteMessage(j, transport.MessageBodyTypeJSON)
 }
 
 func (s IncomingStreamAdapter) SendMessage(msg *message.Message) error {
-	return s.stream.WriteMessage(msg.Raw().Bytes())
+	return s.stream.WriteMessage(msg.Raw().Bytes(), transport.MessageBodyTypeJSON)
 }
 
 func parseIncomingMsg(b []byte) (IncomingMessage, error) {

--- a/service/domain/replication/ebt/replicator_test.go
+++ b/service/domain/replication/ebt/replicator_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/planetary-social/scuttlego/service/domain/replication/ebt"
 	"github.com/planetary-social/scuttlego/service/domain/transport"
 	"github.com/planetary-social/scuttlego/service/domain/transport/rpc"
+	rpctransport "github.com/planetary-social/scuttlego/service/domain/transport/rpc/transport"
 	"github.com/stretchr/testify/require"
 )
 
@@ -195,7 +196,7 @@ func newResponseStreamMock(ctx context.Context) *responseStreamMock {
 	return &responseStreamMock{ctx: ctx}
 }
 
-func (r responseStreamMock) WriteMessage(body []byte) error {
+func (r responseStreamMock) WriteMessage(body []byte, bodyType rpctransport.MessageBodyType) error {
 	return nil
 }
 

--- a/service/domain/rooms/tunnel/adapters.go
+++ b/service/domain/rooms/tunnel/adapters.go
@@ -7,6 +7,7 @@ import (
 	"github.com/boreq/errors"
 	"github.com/planetary-social/scuttlego/service/domain/transport/rpc"
 	"github.com/planetary-social/scuttlego/service/domain/transport/rpc/mux"
+	"github.com/planetary-social/scuttlego/service/domain/transport/rpc/transport"
 )
 
 type ResponseStreamReadWriteCloserAdapter struct {
@@ -41,7 +42,7 @@ func (s ResponseStreamReadWriteCloserAdapter) Read(p []byte) (int, error) {
 }
 
 func (s ResponseStreamReadWriteCloserAdapter) Write(p []byte) (n int, err error) {
-	return len(p), s.stream.WriteMessage(p)
+	return len(p), s.stream.WriteMessage(p, transport.MessageBodyTypeBinary)
 }
 
 func (s ResponseStreamReadWriteCloserAdapter) Close() error {
@@ -82,7 +83,7 @@ func (s StreamReadWriteCloserAdapter) Read(p []byte) (n int, err error) {
 }
 
 func (s StreamReadWriteCloserAdapter) Write(p []byte) (n int, err error) {
-	return len(p), s.stream.WriteMessage(p)
+	return len(p), s.stream.WriteMessage(p, transport.MessageBodyTypeBinary)
 }
 
 func (s StreamReadWriteCloserAdapter) Close() error {

--- a/service/domain/transport/rpc/connection_test.go
+++ b/service/domain/transport/rpc/connection_test.go
@@ -478,7 +478,7 @@ func TestPrematureTerminationByRemote(t *testing.T) {
 				},
 				&transport.Message{
 					Header: transport.MustNewMessageHeader(
-						transport.MustNewMessageHeaderFlags(fixtures.SomeBool(), true, fixtures.SomeMessageBodyType()),
+						transport.MustNewMessageHeaderFlags(fixtures.SomeBool(), true, transport.MessageBodyTypeJSON),
 						fixtures.SomeUint32(),
 						requestNumber,
 					),

--- a/service/domain/transport/rpc/mux/mux.go
+++ b/service/domain/transport/rpc/mux/mux.go
@@ -8,16 +8,17 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/planetary-social/scuttlego/logging"
 	"github.com/planetary-social/scuttlego/service/domain/transport/rpc"
+	"github.com/planetary-social/scuttlego/service/domain/transport/rpc/transport"
 )
 
 type Stream interface {
 	IncomingMessages() (<-chan rpc.IncomingMessage, error)
-	WriteMessage(body []byte) error
+	WriteMessage(body []byte, bodyType transport.MessageBodyType) error
 }
 
 type CloserStream interface {
 	IncomingMessages() (<-chan rpc.IncomingMessage, error)
-	WriteMessage(body []byte) error
+	WriteMessage(body []byte, bodyType transport.MessageBodyType) error
 	CloseWithError(err error) error
 }
 

--- a/service/domain/transport/rpc/mux/mux_test.go
+++ b/service/domain/transport/rpc/mux/mux_test.go
@@ -244,7 +244,7 @@ func TestNewMux_HandlerDoesNotBlock(t *testing.T) {
 		newMockHandler(
 			procedure,
 			func(ctx context.Context, s mux.Stream, req *rpc.Request) error {
-				if err := s.WriteMessage(fixtures.SomeBytes()); err != nil {
+				if err := s.WriteMessage(fixtures.SomeBytes(), fixtures.SomeMessageBodyType()); err != nil {
 					t.Fatal(err)
 				}
 				<-time.After(delay)
@@ -288,7 +288,7 @@ func TestNewMux_SynchronousHandlerBlocks(t *testing.T) {
 		newMockSynchronousHandler(
 			procedure,
 			func(ctx context.Context, s mux.Stream, req *rpc.Request) {
-				if err := s.WriteMessage(fixtures.SomeBytes()); err != nil {
+				if err := s.WriteMessage(fixtures.SomeBytes(), fixtures.SomeMessageBodyType()); err != nil {
 					t.Fatal(err)
 				}
 				<-time.After(delay)

--- a/service/domain/transport/rpc/request_stream.go
+++ b/service/domain/transport/rpc/request_stream.go
@@ -60,15 +60,19 @@ func NewRequestStream(ctx context.Context, number int, typ ProcedureType, raw Me
 	return rs, nil
 }
 
-func (rs *RequestStream) WriteMessage(body []byte) error {
+func (rs *RequestStream) WriteMessage(body []byte, bodyType transport.MessageBodyType) error {
+	if bodyType.IsZero() {
+		return errors.New("zero value of body type")
+	}
+
 	select {
 	case <-rs.ctx.Done():
 		return rs.ctx.Err()
 	default:
 	}
 
-	// todo do this correctly? are the flags correct?
-	flags, err := transport.NewMessageHeaderFlags(true, false, transport.MessageBodyTypeJSON)
+	// todo is the stream flag correct?
+	flags, err := transport.NewMessageHeaderFlags(true, false, bodyType)
 	if err != nil {
 		return errors.Wrap(err, "could not create message header flags")
 	}

--- a/service/domain/transport/rpc/request_stream_test.go
+++ b/service/domain/transport/rpc/request_stream_test.go
@@ -46,13 +46,14 @@ func TestRequestStream_WriteMessageCallsMessageSender(t *testing.T) {
 	require.NoError(t, err)
 
 	body := []byte("some body")
+	bodyType := fixtures.SomeMessageBodyType()
 
-	err = stream.WriteMessage(body)
+	err = stream.WriteMessage(body, bodyType)
 	require.NoError(t, err)
 
 	expectedMessage, err := transport.NewMessage(
 		transport.MustNewMessageHeader(
-			transport.MustNewMessageHeaderFlags(true, false, transport.MessageBodyTypeJSON),
+			transport.MustNewMessageHeaderFlags(true, false, bodyType),
 			uint32(len(body)),
 			int32(-requestNumber),
 		),

--- a/service/domain/transport/rpc/request_streams.go
+++ b/service/domain/transport/rpc/request_streams.go
@@ -19,7 +19,7 @@ type IncomingMessage struct {
 
 type Stream interface {
 	// WriteMessage sends a message over the underlying stream.
-	WriteMessage(body []byte) error
+	WriteMessage(body []byte, bodyType transport.MessageBodyType) error
 
 	// CloseWithError terminates the underlying stream. Error is sent to the
 	// other party. Error can be nil.

--- a/service/domain/transport/rpc/response_streams_test.go
+++ b/service/domain/transport/rpc/response_streams_test.go
@@ -127,6 +127,8 @@ func TestResponseStreams_RequestsAndInStreamMessagesAreCorrectlyMarshaledInDuple
 		rpc.ProcedureTypeDuplex,
 		fixtures.SomeJSON(),
 	)
+
+	inStreamMessageBodyType := fixtures.SomeMessageBodyType()
 	inStreamMessageData := fixtures.SomeBytes()
 
 	streams := rpc.NewResponseStreams(sender, logger)
@@ -134,7 +136,7 @@ func TestResponseStreams_RequestsAndInStreamMessagesAreCorrectlyMarshaledInDuple
 	stream, err := streams.Open(ctx, req)
 	require.NoError(t, err)
 
-	err = stream.WriteMessage(inStreamMessageData)
+	err = stream.WriteMessage(inStreamMessageData, inStreamMessageBodyType)
 	require.NoError(t, err)
 
 	cancel()
@@ -144,7 +146,7 @@ func TestResponseStreams_RequestsAndInStreamMessagesAreCorrectlyMarshaledInDuple
 		1,
 	}
 	expectedInStreamMessage := expectedFlagsAndRequestNumber{
-		transport.MustNewMessageHeaderFlags(true, false, transport.MessageBodyTypeJSON),
+		transport.MustNewMessageHeaderFlags(true, false, inStreamMessageBodyType),
 		1,
 	}
 	expectedTerminationMessage := expectedFlagsAndRequestNumber{
@@ -267,7 +269,7 @@ func TestResponseStreams_ReturnsImplementationForWhichWriteMessageWorksOnlyForDu
 				))
 			require.NoError(t, err)
 
-			err = stream.WriteMessage(fixtures.SomeBytes())
+			err = stream.WriteMessage(fixtures.SomeBytes(), transport.MessageBodyTypeBinary)
 			if testCase.ExpectedError {
 				require.EqualError(t, err, "not a duplex stream")
 			} else {
@@ -421,7 +423,7 @@ func createResponse(req *transport.Message) *transport.Message {
 
 func createCleanTermination(req *transport.Message) *transport.Message {
 	header, err := transport.NewMessageHeader(
-		transport.MustNewMessageHeaderFlags(fixtures.SomeBool(), true, fixtures.SomeMessageBodyType()),
+		transport.MustNewMessageHeaderFlags(fixtures.SomeBool(), true, transport.MessageBodyTypeJSON),
 		4,
 		int32(-req.Header.RequestNumber()),
 	)
@@ -439,7 +441,7 @@ func createCleanTermination(req *transport.Message) *transport.Message {
 
 func createErrorTermination(req *transport.Message) *transport.Message {
 	header, err := transport.NewMessageHeader(
-		transport.MustNewMessageHeaderFlags(fixtures.SomeBool(), true, fixtures.SomeMessageBodyType()),
+		transport.MustNewMessageHeaderFlags(fixtures.SomeBool(), true, transport.MessageBodyTypeJSON),
 		0,
 		int32(-req.Header.RequestNumber()),
 	)

--- a/service/domain/transport/rpc/transport/raw_message.go
+++ b/service/domain/transport/rpc/transport/raw_message.go
@@ -89,9 +89,9 @@ func NewMessageHeader(flags MessageHeaderFlags, bodyLength uint32, requestNumber
 		return MessageHeader{}, errors.New("request number can not be set to zero")
 	}
 
-	if header.IsRequest() && !header.Flags().EndOrError() {
+	if header.Flags().EndOrError() {
 		if flags.BodyType() != MessageBodyTypeJSON {
-			return MessageHeader{}, errors.New("requests should have body type set to JSON")
+			return MessageHeader{}, errors.New("terminations should have body type set to JSON")
 		}
 	}
 

--- a/service/domain/transport/rpc/transport/raw_message_test.go
+++ b/service/domain/transport/rpc/transport/raw_message_test.go
@@ -61,32 +61,32 @@ func TestMessageHeader(t *testing.T) {
 		},
 
 		{
-			Name:          "request_body_type_can_not_be_binary",
+			Name:          "request_body_type_can_be_binary_in_duplex_streams",
 			Flags:         transport.MustNewMessageHeaderFlags(true, false, transport.MessageBodyTypeBinary),
 			BodyLength:    validBodyLength,
 			RequestNumber: validRequestNumber,
-			ExpectedError: errors.New("requests should have body type set to JSON"),
+			ExpectedError: nil,
 		},
 		{
-			Name:          "request_body_type_can_not_be_string",
+			Name:          "request_body_type_can_be_string_in_duplex_streams",
 			Flags:         transport.MustNewMessageHeaderFlags(true, false, transport.MessageBodyTypeString),
 			BodyLength:    validBodyLength,
 			RequestNumber: validRequestNumber,
-			ExpectedError: errors.New("requests should have body type set to JSON"),
+			ExpectedError: nil,
 		},
 		{
-			Name:          "request_body_type_can_be_binary_if_termination",
+			Name:          "request_body_type_can_not_be_binary_if_termination",
 			Flags:         transport.MustNewMessageHeaderFlags(true, true, transport.MessageBodyTypeBinary),
 			BodyLength:    validBodyLength,
 			RequestNumber: validRequestNumber,
-			ExpectedError: nil,
+			ExpectedError: errors.New("terminations should have body type set to JSON"),
 		},
 		{
-			Name:          "request_body_type_can_be_string_if_termination",
+			Name:          "request_body_type_can_not_be_string_if_termination",
 			Flags:         transport.MustNewMessageHeaderFlags(true, true, transport.MessageBodyTypeString),
 			BodyLength:    validBodyLength,
 			RequestNumber: validRequestNumber,
-			ExpectedError: nil,
+			ExpectedError: errors.New("terminations should have body type set to JSON"),
 		},
 
 		{

--- a/service/ports/rpc/handler_blobs_createWants.go
+++ b/service/ports/rpc/handler_blobs_createWants.go
@@ -8,6 +8,7 @@ import (
 	"github.com/planetary-social/scuttlego/service/domain/messages"
 	"github.com/planetary-social/scuttlego/service/domain/transport/rpc"
 	"github.com/planetary-social/scuttlego/service/domain/transport/rpc/mux"
+	"github.com/planetary-social/scuttlego/service/domain/transport/rpc/transport"
 )
 
 type CreateWantsCommandHandler interface {
@@ -50,7 +51,7 @@ func (h HandlerBlobsCreateWants) Handle(ctx context.Context, s mux.Stream, req *
 			return errors.Wrap(err, "json marshalling failed")
 		}
 
-		if err := s.WriteMessage(j); err != nil {
+		if err := s.WriteMessage(j, transport.MessageBodyTypeJSON); err != nil {
 			return errors.Wrap(err, "failed to send a message")
 		}
 	}

--- a/service/ports/rpc/handler_blobs_createWants_test.go
+++ b/service/ports/rpc/handler_blobs_createWants_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/planetary-social/scuttlego/service/domain/refs"
 	transportrpc "github.com/planetary-social/scuttlego/service/domain/transport/rpc"
 	"github.com/planetary-social/scuttlego/service/domain/transport/rpc/mux/mocks"
+	"github.com/planetary-social/scuttlego/service/domain/transport/rpc/transport"
 	"github.com/planetary-social/scuttlego/service/ports/rpc"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -42,12 +43,18 @@ func TestCreateWantsHandlerSendsValuesReturnedByCreateWantsCommand(t *testing.T)
 	require.Eventually(t,
 		func() bool {
 			for i, msg := range s.WrittenMessages() {
-				t.Log(i, string(msg))
+				t.Log(i, msg.BodyType, string(msg.Body))
 			}
 			return assert.ObjectsAreEqual(
-				[][]byte{
-					[]byte(`{"\u0026Uv38ByGCZU8WP18PmmIdcpVmx00QA3xNe7sEB9Hixkk=.sha256":123}`),
-					[]byte(`{"\u0026gYVaHgAWeTnLZpTSxCKs0gigByk5SH9pmeudGKRHhAQ=.sha256":-1}`),
+				[]mocks.MockCloserStreamWriteMessageCall{
+					{
+						Body:     []byte(`{"\u0026Uv38ByGCZU8WP18PmmIdcpVmx00QA3xNe7sEB9Hixkk=.sha256":123}`),
+						BodyType: transport.MessageBodyTypeJSON,
+					},
+					{
+						Body:     []byte(`{"\u0026gYVaHgAWeTnLZpTSxCKs0gigByk5SH9pmeudGKRHhAQ=.sha256":-1}`),
+						BodyType: transport.MessageBodyTypeJSON,
+					},
 				},
 				s.WrittenMessages(),
 			)

--- a/service/ports/rpc/handler_blobs_get.go
+++ b/service/ports/rpc/handler_blobs_get.go
@@ -10,6 +10,7 @@ import (
 	"github.com/planetary-social/scuttlego/service/domain/messages"
 	"github.com/planetary-social/scuttlego/service/domain/transport/rpc"
 	"github.com/planetary-social/scuttlego/service/domain/transport/rpc/mux"
+	"github.com/planetary-social/scuttlego/service/domain/transport/rpc/transport"
 )
 
 const (
@@ -74,7 +75,7 @@ func (h HandlerBlobsGet) Handle(ctx context.Context, s mux.Stream, req *rpc.Requ
 			return nil
 		}
 
-		if err := s.WriteMessage(buf.Bytes()); err != nil {
+		if err := s.WriteMessage(buf.Bytes(), transport.MessageBodyTypeBinary); err != nil {
 			return errors.Wrap(err, "failed to write the message")
 		}
 

--- a/service/ports/rpc/handler_blobs_get_test.go
+++ b/service/ports/rpc/handler_blobs_get_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/planetary-social/scuttlego/service/domain/refs"
 	transportrpc "github.com/planetary-social/scuttlego/service/domain/transport/rpc"
 	"github.com/planetary-social/scuttlego/service/domain/transport/rpc/mux/mocks"
+	"github.com/planetary-social/scuttlego/service/domain/transport/rpc/transport"
 	"github.com/planetary-social/scuttlego/service/ports/rpc"
 	"github.com/stretchr/testify/require"
 )
@@ -136,8 +137,11 @@ func TestSmallBlobIsWrittenToResponseWriter(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t,
-		[][]byte{
-			mockData,
+		[]mocks.MockCloserStreamWriteMessageCall{
+			{
+				Body:     mockData,
+				BodyType: transport.MessageBodyTypeBinary,
+			},
 		},
 		s.WrittenMessages(),
 	)
@@ -169,10 +173,19 @@ func TestLargeBlobIsWrittenToResponseWriter(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t,
-		[][]byte{
-			payloadInFirstMessage,
-			payloadInSecondMessage,
-			payloadInThirdMessage,
+		[]mocks.MockCloserStreamWriteMessageCall{
+			{
+				Body:     payloadInFirstMessage,
+				BodyType: transport.MessageBodyTypeBinary,
+			},
+			{
+				Body:     payloadInSecondMessage,
+				BodyType: transport.MessageBodyTypeBinary,
+			},
+			{
+				Body:     payloadInThirdMessage,
+				BodyType: transport.MessageBodyTypeBinary,
+			},
 		},
 		s.WrittenMessages(),
 	)

--- a/service/ports/rpc/handler_create_history_stream.go
+++ b/service/ports/rpc/handler_create_history_stream.go
@@ -11,6 +11,7 @@ import (
 	"github.com/planetary-social/scuttlego/service/domain/messages"
 	"github.com/planetary-social/scuttlego/service/domain/transport/rpc"
 	"github.com/planetary-social/scuttlego/service/domain/transport/rpc/mux"
+	"github.com/planetary-social/scuttlego/service/domain/transport/rpc/transport"
 )
 
 // CreateHistoryStreamQueryHandler is here to make testing easier. See docs for
@@ -80,7 +81,7 @@ func (rw CreateHistoryStreamResponseWriter) WriteMessage(msg message.Message) er
 		return errors.Wrap(err, "could not create a response")
 	}
 
-	if err := rw.s.WriteMessage(b); err != nil {
+	if err := rw.s.WriteMessage(b, transport.MessageBodyTypeJSON); err != nil {
 		return errors.Wrap(err, "could not write the message")
 	}
 

--- a/service/ports/rpc/handler_create_history_stream_test.go
+++ b/service/ports/rpc/handler_create_history_stream_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/planetary-social/scuttlego/service/domain/messages"
 	transportrpc "github.com/planetary-social/scuttlego/service/domain/transport/rpc"
 	"github.com/planetary-social/scuttlego/service/domain/transport/rpc/mux/mocks"
+	"github.com/planetary-social/scuttlego/service/domain/transport/rpc/transport"
 	"github.com/planetary-social/scuttlego/service/ports/rpc"
 	"github.com/stretchr/testify/require"
 )
@@ -57,9 +58,10 @@ func TestCreateHistoryStream(t *testing.T) {
 
 			msgs := s.WrittenMessages()
 			require.Len(t, msgs, 1)
-			for _, body := range msgs {
+			for _, msg := range msgs {
 				keyJSON := []byte(`"key":`)
-				require.Equal(t, testCase.ContainsKeys, bytes.Contains(body, keyJSON))
+				require.Equal(t, testCase.ContainsKeys, bytes.Contains(msg.Body, keyJSON))
+				require.Equal(t, transport.MessageBodyTypeJSON, msg.BodyType)
 			}
 		})
 	}


### PR DESCRIPTION
Messages which are requests based on headers can have body type set to binary due to the fact that they could be follow-up messages in duplex streams.